### PR TITLE
Added lxml library which is often required by bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 bs4
 alive_progress
+lxml


### PR DESCRIPTION
I was running this, and found that the lxml library dependency from bs4 is not being automatically installed. This PR explicitly defines it.

The error I received before installing lxml was:
```
[~/SeeYouCM-Thief] # python3 thief.py -H 10.22.105.19

___________
                   /.---------.\`-._
                  //          ||    `-._
                  || `-._     ||        `-._
                  ||     `-._ ||            `-._
                  ||    _____ ||`-._            \
            _..._ ||   | __ ! ||    `-._        |
          _/     \||   .'  |~~||        `-._    |
      .-``     _.`||  /   _|~~||    .----.  `-._|
     |      _.`  _||  |  |23| ||   / :::: \    \
     \ _.--`  _.` ||  |  |56| ||  / ::::: |    |
      |   _.-`  _.||  |  |79| ||  |   _..-'   /
      _\-`   _.`O ||  |  |_   ||  |::|        |
    .`    _.`O `._||  \    |  ||  |::|        |
 .-`   _.` `._.'  ||   '.__|--||  |::|        \
`-._.-` \`-._     ||   | ":  !||  |  '-.._    |
         \   `--._||   |_:"___||  | ::::: |   |
          \  /\   ||     ":":"||   \ :::: |   |
           \(  `-.||       .- ||    `.___/    /
           |    | ||   _.-    ||              |
           |    / \.-________\____.....-----'
           \    -.      \ |         |
            \     `.     \ \        |
 __________  `.    .'\    \|        |\  _________
    SeeYouCM   `..'   \    |        | \   Thief
                \   .'    |       /  .`.
                | \.'      |       |.'   `-._
                 \     _ . /       \_\-._____)
                  \_.-`  .`'._____.'`.
                    \_\-|             |
                         `._________.'

Traceback (most recent call last):
  File "thief.py", line 298, in <module>
    get_version(CUCM_host)
  File "thief.py", line 220, in get_version
    soup = BeautifulSoup(lines, 'lxml')
  File "/root/SeeYouCM-Thief/env/lib/python3.6/site-packages/bs4/__init__.py", line 251, in __init__
    % ",".join(features))
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?
```