### PR TITLE
adding lxml to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 bs4
 alive_progress
+lxml


### PR DESCRIPTION
when parsing XML, BeautifulSoup requires the lxml package to be installed (such as in a virtual env)

![missingLibrary](https://github.com/user-attachments/assets/80895845-21ff-43af-bc7b-f25acb53282b)


(Also love this tool! Great work by all involved and much love to the excellent blog post by Justin Bollinger in creating this!)