### PR TITLE
Parse flat <server>HOSTNAME</server> UDS responses

### DIFF
--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -563,6 +563,12 @@ def get_servers_api(cucm_host, port=UDS_PORT, timeout=10):
             m = re.search(rf'<{field}>([^<]+)</{field}>', block)
             if m:
                 srv[field] = m.group(1).strip()
+        if not srv:
+            # Newer UDS (15.x+) returns the hostname as plain text inside
+            # <server>...</server> with no child elements.
+            text = re.sub(r'<[^>]+>', '', block).strip()
+            if text:
+                srv['hostName'] = text
         if srv:
             servers.append(srv)
     dbg(f'UDS parsed {len(servers)} server entries from cluster topology')


### PR DESCRIPTION
## Summary
CUCM UDS 15.x returns cluster topology as plain text inside `<server>...</server>` rather than nested `<hostName>` / `<ipv4Address>` children. The previous parser silently returned 0 entries for those clusters. Fall back to the element's text content when no nested fields are present.

## Test plan
- [x] Mocked suite passes
- [x] Smoke test against a literal 15.x-shaped response parses all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)