### PR TITLE
feat: add --extract-configs DIR to dump cached configs to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ View cached results:
 ./thief.py --show-db -H <CUCM Server>  # Filter by CUCM
 ```
 
+Extract all cached configs to disk for offline review:
+
+```bash
+./thief.py --extract-configs ./configs
+./thief.py --extract-configs ./configs --db custom.db
+```
+
+Files are written to `./configs/<cucm_host>/<filename>`. Existing files are
+preserved (re-runs are safe and incremental). Only successful downloads
+with non-empty content are extracted.
+
 Force re-download (bypass cache):
 
 ```bash
@@ -134,6 +145,7 @@ Export to CSV:
 - `--db FILENAME`: Specify SQLite database for caching results (default: thief.db)
 - `--no-db`: Disable database caching and operate without persistent storage
 - `--show-db`: Display summary of credentials stored in database and exit
+- `--extract-configs DIR`: Extract all cached configuration files from the database into `DIR/<cucm_host>/<filename>` and exit
 
 ### Debugging
 - `-d, --debug`: Enable verbose output including all failed attempts and TFTP operations

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1444,6 +1444,88 @@ def device_key_for_result(full_mac, filename):
     return f'SEP{full_mac}'
 
 
+def extract_configs_from_db(db_file, output_dir, debug=False):
+    """Read successful download rows from the cache and materialize them
+    as files under output_dir/<cucm_host>/<filename>.
+
+    Returns (written, skipped, errors) counts.
+
+    - written: files newly created from DB content.
+    - skipped: target file already existed; left untouched.
+    - errors: row was rejected (path-traversal sanitization, write failure).
+
+    Raises FileNotFoundError if db_file does not exist. Other DB-level
+    failures (locked, schema mismatch) propagate as sqlite3 errors.
+    """
+    if not os.path.exists(db_file):
+        raise FileNotFoundError(f'Database file not found: {db_file}')
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    conn = sqlite3.connect(db_file)
+    cursor = conn.cursor()
+    cursor.execute('''
+        SELECT cucm_host, filename, content
+        FROM download_attempts
+        WHERE success = 1
+          AND content IS NOT NULL
+          AND length(content) > 0
+        ORDER BY cucm_host, filename
+    ''')
+    rows = cursor.fetchall()
+    conn.close()
+
+    written = 0
+    skipped = 0
+    errors = 0
+    skipped_paths = []
+    error_paths = []
+
+    print(f'[*] Extracting configs from {db_file} to {output_dir}/')
+    print(f'[*] Found {len(rows)} rows with non-empty content')
+
+    for cucm_host, filename, content in rows:
+        safe_cucm = os.path.basename(cucm_host or '')
+        safe_filename = os.path.basename(filename or '')
+        if not safe_cucm or not safe_filename or safe_cucm != cucm_host or safe_filename != filename:
+            errors += 1
+            error_paths.append(f'{cucm_host}/{filename} (path-traversal guard)')
+            continue
+
+        cucm_dir = os.path.join(output_dir, safe_cucm)
+        target_path = os.path.join(cucm_dir, safe_filename)
+
+        if os.path.exists(target_path):
+            skipped += 1
+            skipped_paths.append(target_path)
+            continue
+
+        try:
+            os.makedirs(cucm_dir, exist_ok=True)
+            with open(target_path, 'w', encoding='utf-8') as f:
+                f.write(content)
+            if debug:
+                print(f'[+] Wrote {target_path}')
+            written += 1
+        except OSError as e:
+            errors += 1
+            error_paths.append(f'{target_path}: {e}')
+
+    if skipped_paths:
+        print(f'[!] Skipped {skipped} files (already exist):')
+        for p in skipped_paths:
+            print(f'    {p}')
+
+    if error_paths:
+        print(f'[!] Errors on {errors} rows:')
+        for p in error_paths:
+            print(f'    {p}')
+
+    print(f'[*] Done: {written} written, {skipped} skipped, {errors} errors')
+
+    return written, skipped, errors
+
+
 def main():
     global debug, found_credentials, found_usernames, file_names, hostnames, db_file, no_db, force_download
     

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1570,6 +1570,8 @@ def main():
 
     # Handle --show-db early (display database summary and exit)
     if args.show_db:
+        if args.extract_configs is not None:
+            print('[!] --extract-configs ignored because --show-db takes precedence')
         db_file = args.db
         cucm_filter = args.host
         if args.csv:
@@ -1609,7 +1611,7 @@ def main():
         quit(0)
 
     # Handle --extract-configs (dump cached configs to disk and exit)
-    if args.extract_configs:
+    if args.extract_configs is not None:
         if args.no_db:
             print('[-] --extract-configs requires the database (cannot be combined with --no-db)')
             quit(1)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1463,17 +1463,19 @@ def extract_configs_from_db(db_file, output_dir, debug=False):
     os.makedirs(output_dir, exist_ok=True)
 
     conn = sqlite3.connect(db_file)
-    cursor = conn.cursor()
-    cursor.execute('''
-        SELECT cucm_host, filename, content
-        FROM download_attempts
-        WHERE success = 1
-          AND content IS NOT NULL
-          AND length(content) > 0
-        ORDER BY cucm_host, filename
-    ''')
-    rows = cursor.fetchall()
-    conn.close()
+    try:
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT cucm_host, filename, content
+            FROM download_attempts
+            WHERE success = 1
+              AND content IS NOT NULL
+              AND length(content) > 0
+            ORDER BY cucm_host, filename
+        ''')
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
 
     written = 0
     skipped = 0

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1561,7 +1561,8 @@ def main():
     parser.add_argument('--db', type=str, metavar='FILENAME', default='thief.db', help='Specify SQLite database for caching results (default: thief.db)')
     parser.add_argument('--no-db', action='store_true', default=False, help='Disable database caching and operate without persistent storage')
     parser.add_argument('--show-db', action='store_true', default=False, help='Display summary of credentials stored in database and exit')
-    
+    parser.add_argument('--extract-configs', type=str, metavar='DIR', default=None, help='Extract all cached configuration files from the database into DIR/<cucm_host>/<filename> and exit')
+
     # Debugging
     parser.add_argument('-d','--debug', action='store_true', default=False, help='Enable verbose output including all failed attempts and TFTP operations')
 
@@ -1606,6 +1607,23 @@ def main():
                 print(f'[-] Error exporting credentials to CSV: {e}')
         display_database_summary(db_file, cucm_filter)
         quit(0)
+
+    # Handle --extract-configs (dump cached configs to disk and exit)
+    if args.extract_configs:
+        if args.no_db:
+            print('[-] --extract-configs requires the database (cannot be combined with --no-db)')
+            quit(1)
+        try:
+            written, skipped, errors = extract_configs_from_db(
+                args.db, args.extract_configs, debug=args.debug
+            )
+        except FileNotFoundError as e:
+            print(f'[-] {e}')
+            print('[-] Run a scan first to populate the database, or point --db at an existing file.')
+            quit(1)
+        # Per spec: exit 1 if any row failed to write. Empty DB (0 rows, 0
+        # errors) is a legitimate clean exit.
+        quit(1 if errors > 0 else 0)
 
     CUCM_host = args.host
     phones = args.phone if args.phone else []

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -92,3 +92,27 @@ class TestExtractConfigsFilter:
         assert not (out_dir / '10.0.1.5' / 'FAIL.cnf.xml').exists()
         assert not (out_dir / '10.0.1.5' / 'NULL.cnf.xml').exists()
         assert not (out_dir / '10.0.1.5' / 'EMPTY.cnf.xml').exists()
+
+
+class TestExtractConfigsSkipExisting:
+    def test_existing_file_is_left_untouched(self, tmp_path):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        _make_db_with_rows(db_path, [
+            {'cucm_host': '10.0.1.5', 'filename': 'SEP1.cnf.xml',
+             'success': 1, 'content': '<xml>from-db</xml>'},
+        ])
+        # Pre-create the target file with different content.
+        target = out_dir / '10.0.1.5' / 'SEP1.cnf.xml'
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text('manually-edited')
+
+        written, skipped, errors = thief.extract_configs_from_db(
+            str(db_path), str(out_dir)
+        )
+
+        assert written == 0
+        assert skipped == 1
+        assert errors == 0
+        # The manually-edited content must NOT be overwritten.
+        assert target.read_text() == 'manually-edited'

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -168,3 +168,16 @@ class TestExtractConfigsEmptyDb:
         assert errors == 0
         # output_dir was created even though no files were written.
         assert out_dir.exists() and out_dir.is_dir()
+
+
+class TestExtractConfigsMissingDb:
+    def test_missing_db_raises_filenotfound(self, tmp_path):
+        missing_db = tmp_path / 'does-not-exist.db'
+        out_dir = tmp_path / 'configs'
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            thief.extract_configs_from_db(str(missing_db), str(out_dir))
+
+        assert 'does-not-exist.db' in str(excinfo.value)
+        # output_dir should NOT have been created when the DB is missing.
+        assert not out_dir.exists()

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -60,3 +60,35 @@ class TestExtractConfigsHappyPath:
         assert (out_dir / '10.0.1.5' / 'SEPAABBCC112233.cnf.xml').read_text() == '<xml>device-a</xml>'
         assert (out_dir / '10.0.1.5' / 'XMLDefault.cnf.xml').read_text() == '<xml>default-a</xml>'
         assert (out_dir / '10.0.1.6' / 'SEPAABBCC445566.cnf.xml').read_text() == '<xml>device-b</xml>'
+
+
+class TestExtractConfigsFilter:
+    def test_skips_failures_null_and_empty_content(self, tmp_path):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        _make_db_with_rows(db_path, [
+            # Should be written
+            {'cucm_host': '10.0.1.5', 'filename': 'KEEP1.cnf.xml',
+             'success': 1, 'content': '<xml>keep</xml>'},
+            # success=0 — must be skipped even if content is present
+            {'cucm_host': '10.0.1.5', 'filename': 'FAIL.cnf.xml',
+             'success': 0, 'content': '<xml>should-not-write</xml>'},
+            # content is NULL — must be skipped
+            {'cucm_host': '10.0.1.5', 'filename': 'NULL.cnf.xml',
+             'success': 1, 'content': None},
+            # content is empty string — must be skipped
+            {'cucm_host': '10.0.1.5', 'filename': 'EMPTY.cnf.xml',
+             'success': 1, 'content': ''},
+        ])
+
+        written, skipped, errors = thief.extract_configs_from_db(
+            str(db_path), str(out_dir)
+        )
+
+        assert written == 1
+        assert skipped == 0
+        assert errors == 0
+        assert (out_dir / '10.0.1.5' / 'KEEP1.cnf.xml').exists()
+        assert not (out_dir / '10.0.1.5' / 'FAIL.cnf.xml').exists()
+        assert not (out_dir / '10.0.1.5' / 'NULL.cnf.xml').exists()
+        assert not (out_dir / '10.0.1.5' / 'EMPTY.cnf.xml').exists()

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -1,0 +1,62 @@
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import thief
+
+
+def _make_db_with_rows(db_path, rows):
+    """Create a thief-schema DB at db_path and insert the given rows.
+
+    rows is a list of dicts with keys: cucm_host, filename, success,
+    content (any of which may be omitted to use defaults).
+    """
+    thief.init_database(str(db_path))
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    for row in rows:
+        cursor.execute(
+            '''INSERT OR REPLACE INTO download_attempts
+               (cucm_host, filename, attempt_time, success, method, content)
+               VALUES (?, ?, ?, ?, ?, ?)''',
+            (
+                row.get('cucm_host', '10.0.0.1'),
+                row.get('filename', 'SEP000000000001.cnf.xml'),
+                '2026-05-20 12:00:00',
+                row.get('success', 1),
+                row.get('method', 'TFTP'),
+                row.get('content', '<xml>ok</xml>'),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestExtractConfigsHappyPath:
+    def test_writes_files_under_per_cucm_subdirs(self, tmp_path):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        _make_db_with_rows(db_path, [
+            {'cucm_host': '10.0.1.5', 'filename': 'SEPAABBCC112233.cnf.xml',
+             'success': 1, 'content': '<xml>device-a</xml>'},
+            {'cucm_host': '10.0.1.5', 'filename': 'XMLDefault.cnf.xml',
+             'success': 1, 'content': '<xml>default-a</xml>'},
+            {'cucm_host': '10.0.1.6', 'filename': 'SEPAABBCC445566.cnf.xml',
+             'success': 1, 'content': '<xml>device-b</xml>'},
+        ])
+
+        written, skipped, errors = thief.extract_configs_from_db(
+            str(db_path), str(out_dir)
+        )
+
+        assert written == 3
+        assert skipped == 0
+        assert errors == 0
+
+        assert (out_dir / '10.0.1.5' / 'SEPAABBCC112233.cnf.xml').read_text() == '<xml>device-a</xml>'
+        assert (out_dir / '10.0.1.5' / 'XMLDefault.cnf.xml').read_text() == '<xml>default-a</xml>'
+        assert (out_dir / '10.0.1.6' / 'SEPAABBCC445566.cnf.xml').read_text() == '<xml>device-b</xml>'

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -210,3 +210,60 @@ class TestExtractConfigsDebugLogging:
         captured = capsys.readouterr()
         assert '[+] Wrote' in captured.out
         assert 'SEP1.cnf.xml' in captured.out
+
+
+class TestExtractConfigsCli:
+    def test_cli_extracts_files(self, tmp_path):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        _make_db_with_rows(db_path, [
+            {'cucm_host': '10.0.1.5', 'filename': 'CLI1.cnf.xml',
+             'success': 1, 'content': '<xml>cli-1</xml>'},
+            {'cucm_host': '10.0.1.6', 'filename': 'CLI2.cnf.xml',
+             'success': 1, 'content': '<xml>cli-2</xml>'},
+        ])
+
+        result = subprocess.run(
+            [sys.executable, 'thief.py',
+             '--db', str(db_path),
+             '--extract-configs', str(out_dir)],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert (out_dir / '10.0.1.5' / 'CLI1.cnf.xml').read_text() == '<xml>cli-1</xml>'
+        assert (out_dir / '10.0.1.6' / 'CLI2.cnf.xml').read_text() == '<xml>cli-2</xml>'
+        assert 'Done: 2 written' in result.stdout
+
+    def test_cli_rejects_no_db_combo(self, tmp_path):
+        out_dir = tmp_path / 'configs'
+
+        result = subprocess.run(
+            [sys.executable, 'thief.py',
+             '--no-db',
+             '--extract-configs', str(out_dir)],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert '--no-db' in combined or 'no-db' in combined
+        assert not out_dir.exists()
+
+    def test_cli_missing_db_exits_nonzero(self, tmp_path):
+        out_dir = tmp_path / 'configs'
+        missing_db = tmp_path / 'nope.db'
+
+        result = subprocess.run(
+            [sys.executable, 'thief.py',
+             '--db', str(missing_db),
+             '--extract-configs', str(out_dir)],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert 'nope.db' in combined or 'not found' in combined.lower()

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -150,3 +150,21 @@ class TestExtractConfigsPathTraversal:
         # Nothing escaped output_dir.
         assert not outside.exists()
         assert not (tmp_path / 'evil.txt').exists()
+
+
+class TestExtractConfigsEmptyDb:
+    def test_empty_db_returns_zero_counts(self, tmp_path):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        # Initialize schema but insert no matching rows.
+        thief.init_database(str(db_path))
+
+        written, skipped, errors = thief.extract_configs_from_db(
+            str(db_path), str(out_dir)
+        )
+
+        assert written == 0
+        assert skipped == 0
+        assert errors == 0
+        # output_dir was created even though no files were written.
+        assert out_dir.exists() and out_dir.is_dir()

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -181,3 +181,32 @@ class TestExtractConfigsMissingDb:
         assert 'does-not-exist.db' in str(excinfo.value)
         # output_dir should NOT have been created when the DB is missing.
         assert not out_dir.exists()
+
+
+class TestExtractConfigsDebugLogging:
+    def test_per_file_lines_only_in_debug_mode(self, tmp_path, capsys):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        _make_db_with_rows(db_path, [
+            {'cucm_host': '10.0.1.5', 'filename': 'SEP1.cnf.xml',
+             'success': 1, 'content': '<xml>a</xml>'},
+        ])
+
+        # Default mode: no per-file [+] Wrote lines.
+        thief.extract_configs_from_db(str(db_path), str(out_dir), debug=False)
+        captured = capsys.readouterr()
+        assert '[+] Wrote' not in captured.out
+        assert 'Done: 1 written' in captured.out
+
+    def test_per_file_lines_emitted_with_debug(self, tmp_path, capsys):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        _make_db_with_rows(db_path, [
+            {'cucm_host': '10.0.1.5', 'filename': 'SEP1.cnf.xml',
+             'success': 1, 'content': '<xml>a</xml>'},
+        ])
+
+        thief.extract_configs_from_db(str(db_path), str(out_dir), debug=True)
+        captured = capsys.readouterr()
+        assert '[+] Wrote' in captured.out
+        assert 'SEP1.cnf.xml' in captured.out

--- a/tests/test_extract_configs.py
+++ b/tests/test_extract_configs.py
@@ -116,3 +116,37 @@ class TestExtractConfigsSkipExisting:
         assert errors == 0
         # The manually-edited content must NOT be overwritten.
         assert target.read_text() == 'manually-edited'
+
+
+class TestExtractConfigsPathTraversal:
+    def test_malicious_filename_is_rejected(self, tmp_path):
+        db_path = tmp_path / 'thief.db'
+        out_dir = tmp_path / 'configs'
+        outside = tmp_path / 'evil.txt'
+
+        _make_db_with_rows(db_path, [
+            # filename contains traversal — must be rejected.
+            {'cucm_host': '10.0.1.5',
+             'filename': '../evil.txt',
+             'success': 1, 'content': 'pwned'},
+            # cucm_host contains traversal — must be rejected.
+            {'cucm_host': '../../etc',
+             'filename': 'passwd',
+             'success': 1, 'content': 'pwned'},
+            # One clean row to ensure the loop continues after rejects.
+            {'cucm_host': '10.0.1.5', 'filename': 'OK.cnf.xml',
+             'success': 1, 'content': '<xml>ok</xml>'},
+        ])
+
+        written, skipped, errors = thief.extract_configs_from_db(
+            str(db_path), str(out_dir)
+        )
+
+        assert written == 1
+        assert skipped == 0
+        assert errors == 2
+        # The clean row was written.
+        assert (out_dir / '10.0.1.5' / 'OK.cnf.xml').exists()
+        # Nothing escaped output_dir.
+        assert not outside.exists()
+        assert not (tmp_path / 'evil.txt').exists()


### PR DESCRIPTION
## Summary

Adds a `--extract-configs DIR` CLI flag that reads successful download rows from `thief.db` and materializes each as a file at `DIR/<cucm_host>/<filename>` for offline review. Offline-only (no network, no DB writes). Per-CUCM subdirectory layout disambiguates files with the same name across multiple CUCMs (e.g., `ITLFile.tlv`, `XMLDefault.cnf.xml`).

- New helper `extract_configs_from_db(db_file, output_dir, debug=False)` returning `(written, skipped, errors)`
- New argparse flag wired into `main()` after the existing `--show-db` handler
- Path-traversal sanitization via `os.path.basename()` with pre/post equality check
- Pre-existing files are skipped (re-runs are safe and incremental)
- `--no-db` combo and missing-DB cases exit non-zero with actionable messages
- 11 new pytest tests; full suite: 113 passed, 2 skipped

## Usage

```bash
./thief.py --extract-configs ./configs
./thief.py --extract-configs ./configs --db custom.db
```

Output layout:

```
./configs/
  10.0.1.5/
    SEPAABBCC112233.cnf.xml
    XMLDefault.cnf.xml
    ITLFile.tlv
  10.0.1.6/
    SEPAABBCC445566.cnf.xml
```

## Design

- Spec: `docs/superpowers/specs/2026-05-20-extract-configs-design.md` (excluded from git per project convention)
- Implementation plan: `docs/superpowers/plans/2026-05-20-extract-configs.md` (excluded from git per project convention)

## Test plan

- [x] `uv run pytest -q` — 113 passed, 2 skipped (integration tests gated on `REAL_PHONE_IP`)
- [x] `uv run thief --help | grep extract-configs` — flag visible
- [x] Smoke test against real (empty) `thief.db` — exits 0, creates output dir, no spurious files
- [ ] Smoke test against a populated `thief.db` from a real engagement

🤖 Generated with [Claude Code](https://claude.com/claude-code)