### PR TITLE
fix: reuse DB-discovered phones for --brute-mac when -p omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Export to CSV:
 - `-e, --enumsubnet`: Enumerate and attack subnet in CIDR notation
 
 ### Attack Options
-- `-b, --brute-mac`: Brute force MAC variations (4,096 combinations per phone)
+- `-b, --brute-mac`: Brute force MAC variations (4,096 combinations per phone). If no `-p` phones are given, reuses MAC prefixes discovered on a previous scan from the database (unless `--no-db`)
 - `--force`: Bypass cache and force re-download of all configuration files
 - `--userenum`: Extract usernames via CUCM User Data Services (UDS) API (paginates the full directory)
 - `--servers`: Enumerate CUCM cluster members (hostnames + IPs) via UDS `/cucm-uds/servers` — requires `-H`

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -816,6 +816,36 @@ def get_known_cucm_hosts(db_file='thief.db'):
     return sorted(hosts)
 
 
+def get_mac_prefixes_from_db(db_file='thief.db'):
+    """
+    Return previously discovered MAC prefixes as a list of (full_mac, cucm_host)
+    tuples, newest first. Rows missing a full MAC or CUCM host are dropped since
+    brute force needs both. Lets --brute-mac run without -p by reusing phones
+    discovered on an earlier scan.
+    """
+    rows = []
+    try:
+        conn = sqlite3.connect(db_file, timeout=30.0)
+        cursor = conn.cursor()
+        try:
+            cursor.execute('''
+                SELECT full_mac, cucm_host
+                FROM mac_prefixes
+                ORDER BY discovery_time DESC
+            ''')
+            for full_mac, cucm_host in cursor.fetchall():
+                if full_mac and cucm_host:
+                    rows.append((full_mac.upper(), cucm_host))
+        except sqlite3.OperationalError as e:
+            if 'no such table' not in str(e):
+                raise
+        conn.close()
+    except Exception as e:
+        if globals().get('debug', False):
+            print(f'[!] get_mac_prefixes_from_db error: {e}')
+    return rows
+
+
 def parse_uds_devices(xml_body):
     """Extract SEP device names from a /cucm-uds/user/{id} XML response body."""
     return re.findall(r'<device>(SEP[0-9A-Fa-f]{12})</device>', xml_body)
@@ -2637,16 +2667,33 @@ def main():
 
     # Handle MAC brute forcing from detected phones
     if brute_mac:
-        if not phones:
-            print('You must specify at least one phone with -p when using --brute-mac')
-            quit(1)
-        
-        print(f'MAC brute force mode enabled for {len(phones)} phone(s) with suffix length {brute_mac_len}\n')
-        
         # Map each MAC prefix to its CUCM server
         mac_to_cucm = {}
         all_found_macs = set()
-        
+
+        if phones:
+            print(f'MAC brute force mode enabled for {len(phones)} phone(s) with suffix length {brute_mac_len}\n')
+        else:
+            # No phones supplied: reuse MAC prefixes discovered on a previous scan.
+            db_prefixes = [] if no_db else get_mac_prefixes_from_db(db_file)
+            if CUCM_host:
+                db_prefixes = [(fm, c) for fm, c in db_prefixes if c == CUCM_host]
+            if not db_prefixes:
+                print('You must specify at least one phone with -p when using --brute-mac')
+                if not no_db:
+                    print('  (and no previously discovered phones were found in the database)')
+                quit(1)
+            prefix_len = 12 - brute_mac_len
+            if prefix_len < 0:
+                print(f'Invalid brute_mac_len: {brute_mac_len} (must be <= 12)')
+                quit(1)
+            for full_mac, cucm in db_prefixes:
+                partial_mac = full_mac[:prefix_len]
+                all_found_macs.add(partial_mac)
+                mac_to_cucm[partial_mac] = CUCM_host or cucm
+            print(f'MAC brute force mode enabled using {len(all_found_macs)} MAC '
+                  f'prefix(es) from the database with suffix length {brute_mac_len}\n')
+
         # Detect MACs and CUCM from each phone (parallel)
         counts = {"success": 0, "fail": 0}
         detect_lock = threading.Lock()
@@ -2747,7 +2794,8 @@ def main():
             for t in detect_threads:
                 t.join()
         
-        print(f'Phone detection complete: {counts["success"]} succeeded, {counts["fail"]} failed\n')
+        if phones:
+            print(f'Phone detection complete: {counts["success"]} succeeded, {counts["fail"]} failed\n')
         
         if not all_found_macs:
             print('No MAC addresses detected. Cannot proceed with brute force.')

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -49,3 +49,30 @@ def test_log_download_and_credentials(tmp_path):
     assert user_row[1] == "device2"
     assert user_row[2] == "user2"
     conn.close()
+
+def test_get_mac_prefixes_from_db(tmp_path):
+    db_path = tmp_path / "test_thief.db"
+    thief.init_database(str(db_path))
+    # Two prefixes with CUCM hosts, plus one row with no CUCM that must be dropped.
+    thief.log_mac_prefix_to_db("10.0.0.1", "192.168.1.10", "AABBCCDDEE01", "AABBCCDDE", str(db_path))
+    thief.log_mac_prefix_to_db("10.0.0.2", "192.168.1.11", "112233445566", "112233445", str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT OR IGNORE INTO mac_prefixes (cucm_host, phone_ip, full_mac, partial_mac, discovery_time)"
+        " VALUES ('', '192.168.1.12', 'FFEEDDCCBBAA', 'FFEEDDCCB', '2024-01-01 00:00:00')"
+    )
+    conn.commit()
+    conn.close()
+
+    rows = thief.get_mac_prefixes_from_db(str(db_path))
+    assert ("AABBCCDDEE01", "10.0.0.1") in rows
+    assert ("112233445566", "10.0.0.2") in rows
+    # Row without a CUCM host is excluded
+    assert all(cucm for _, cucm in rows)
+    assert len(rows) == 2
+
+def test_get_mac_prefixes_from_db_missing_table(tmp_path):
+    # An empty/blank DB file with no tables returns [] rather than raising.
+    db_path = tmp_path / "empty.db"
+    sqlite3.connect(db_path).close()
+    assert thief.get_mac_prefixes_from_db(str(db_path)) == []


### PR DESCRIPTION
## Problem
`--brute-mac` errored with `You must specify at least one phone with -p` whenever `-p` was omitted — even when a previous scan had already populated the `mac_prefixes` table. Those discovered phones were unusable.

## Fix
With no `-p` phones, brute force now falls back to MAC prefixes stored in the database:
- recomputes each partial MAC against the current `--brute-mac` suffix length
- seeds the candidate list directly, skipping live phone detection
- filters to `-H` when a host is given

The original error only fires when there's genuinely nothing to use: no `-p` **and** either `--no-db` or an empty `mac_prefixes` table.

## Changes
- New `get_mac_prefixes_from_db()` DB reader (drops rows missing a MAC or CUCM host; handles missing table)
- Branch the `--brute-mac` flow on whether `-p` phones were supplied
- Guard the "Phone detection complete" line so the DB path doesn't print a misleading `0 succeeded, 0 failed`
- README updated; two new unit tests

## Tests
`uv run pytest -q` → 199 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)