### PR TITLE
feat: query both UDS device endpoints in --uds-devices sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Authenticate to the UDS API with a single end-user credential, enumerate **all**
 
 Authorization reality: a standard end user can usually only read their own record, so on a strict server most users return *denied* and you mainly recover the authenticated user's own devices; on permissive or privileged setups you get the full set. The run prints an ok/denied/error tally so you can see how the server responded.
 
+For each user the sweep queries **both** `/cucm-uds/user/{id}` and `/cucm-uds/user/{id}/devices` and unions the SEP names, so a host that misconfigures authorization on one endpoint but not the other still yields devices. This roughly doubles the request volume per user — tune with `-T/--threads`.
+
 `--uds-devices` requires `-H/--host`, `--uds-user`, and `--uds-password`. It needs **only end-user credentials** — no CCM Admin or AXL access is required. It honors `--uds-port` (default: 8443), `--no-db`, and `-T/--threads` for sweep concurrency.
 
 ### Password Spray

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -851,6 +851,15 @@ def parse_uds_devices(xml_body):
     return re.findall(r'<device>(SEP[0-9A-Fa-f]{12})</device>', xml_body)
 
 
+def parse_uds_device_collection(xml_body):
+    """Extract SEP device names from a /cucm-uds/user/{id}/devices response body.
+
+    That endpoint wraps each device in a <device> element with child fields; the
+    SEP name lives in <name>SEP…</name> (unlike the /user/{id} associatedDevices
+    shape, where it is the bare <device> text — see parse_uds_devices)."""
+    return re.findall(r'<name>(SEP[0-9A-Fa-f]{12})</name>', xml_body)
+
+
 def log_uds_device(cucm_host, username, device_name, source, db_file='thief.db'):
     """Insert a (cucm_host, username, device_name) row into uds_devices; ignores duplicates."""
     timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1157,6 +1157,9 @@ def _spray_worker(work_queue, results, password, cucm_host, port, db_file, dead_
         log_spray_attempt(cucm_host, username, effective_password, status_code, error, db_file)
 
         if status_code == 200 and resp is not None:
+            # Spray hits only the base /cucm-uds/user/{id} endpoint, so the
+            # associatedDevices parser is correct here (device discovery's
+            # two-endpoint union lives in get_user_devices_authenticated).
             for device_name in parse_uds_devices(resp.text):
                 log_uds_device(cucm_host, username, device_name, 'spray_hit', db_file)
 

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -989,32 +989,60 @@ def enumerate_devices_authenticated(cucm_host, username, password, port, usernam
 
 def get_user_devices_authenticated(cucm_host, username, password, port=UDS_PORT, timeout=10, target_user=None):
     """
-    Authenticated UDS lookup: GET /cucm-uds/user/{target_user} authenticating as
-    (username, password) via HTTP Basic auth. target_user defaults to username
-    (query your own record). Passing a different target_user queries another
-    user's record with the same credential — useful for sweeping all users with
-    one working credential; the server decides whether to authorize it.
+    Authenticated UDS device lookup for one user, querying BOTH endpoints that
+    can expose device names and unioning the results — so a server that
+    misconfigures authorization on one but not the other still yields devices:
+      - /cucm-uds/user/{target}          -> <device>SEP…</device> (associatedDevices)
+      - /cucm-uds/user/{target}/devices  -> <name>SEP…</name>      (device collection)
+
+    Authenticates as (username, password) via HTTP Basic auth. target_user
+    defaults to username (your own record). A different target_user queries
+    another user's record with the same credential; the server decides whether
+    to authorize it.
 
     Returns (status, devices):
-      'ok'           — HTTP 200; devices is the parsed SEP list (may be empty).
-      'unauthorized' — HTTP 401; creds rejected. devices is [].
-      'error'        — network failure or other status. devices is [].
+      'ok'           — at least one endpoint returned HTTP 200; devices is the
+                       order-preserving deduped union of SEPs from both.
+      'unauthorized' — neither returned 200 but at least one returned HTTP 401.
+      'error'        — neither returned 200 or 401 (network failure / other).
     """
     target = target_user if target_user is not None else username
-    url = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(target, safe="")}'
-    dbg(f'UDS authed GET {url} (timeout={timeout}s)')
-    try:
-        resp = requests.get(url, auth=(username, password), verify=False, timeout=timeout)
-    except Exception as e:
-        dbg(f'UDS authed {url} raised {type(e).__name__}: {e}')
-        return 'error', []
-    dbg(f'UDS authed {url} -> {resp.status_code} ({len(resp.content)} bytes)')
-    if resp.status_code == 200:
-        return 'ok', parse_uds_devices(resp.text)
-    if resp.status_code == 401:
-        return 'unauthorized', []
-    dbg(f'UDS authed non-200/401 body (first 300 chars): {resp.text[:300]!r}')
-    return 'error', []
+    base = f'https://{cucm_host}:{port}/cucm-uds/user/{quote(target, safe="")}'
+    endpoints = (
+        (base, parse_uds_devices),
+        (f'{base}/devices', parse_uds_device_collection),
+    )
+
+    statuses = []
+    devices = []
+    for url, parser in endpoints:
+        dbg(f'UDS authed GET {url} (timeout={timeout}s)')
+        try:
+            resp = requests.get(url, auth=(username, password), verify=False, timeout=timeout)
+        except Exception as e:
+            dbg(f'UDS authed {url} raised {type(e).__name__}: {e}')
+            statuses.append('error')
+            continue
+        dbg(f'UDS authed {url} -> {resp.status_code} ({len(resp.content)} bytes)')
+        if resp.status_code == 200:
+            statuses.append('ok')
+            devices.extend(parser(resp.text))
+        elif resp.status_code == 401:
+            statuses.append('unauthorized')
+        else:
+            dbg(f'UDS authed non-200/401 body (first 300 chars): {resp.text[:300]!r}')
+            statuses.append('error')
+
+    if 'ok' in statuses:
+        status = 'ok'
+    elif 'unauthorized' in statuses:
+        status = 'unauthorized'
+    else:
+        status = 'error'
+
+    seen = set()
+    deduped = [d for d in devices if not (d in seen or seen.add(d))]
+    return status, deduped
 
 
 def download_uds_discovered_configs(cucm_host, device_names, db_file, use_tftp=True, no_db=False):

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -228,8 +228,17 @@ def test_get_user_devices_authenticated_returns_error_on_unexpected_status():
 
 
 def test_get_user_devices_authenticated_unions_both_endpoints():
-    base_resp = MagicMock(status_code=200, text=UDS_USER_XML)
-    devices_resp = MagicMock(status_code=200, text=UDS_DEVICE_COLLECTION_XML)
+    # base returns one unique SEP; /devices returns a different one.
+    base_resp = MagicMock(
+        status_code=200,
+        text="<user><associatedDevices>"
+             "<device>SEP001122334455</device>"
+             "</associatedDevices></user>",
+    )
+    devices_resp = MagicMock(
+        status_code=200,
+        text="<devices><device><name>SEPAABBCCDDEEFF</name></device></devices>",
+    )
 
     def side_effect(url, **kwargs):
         return devices_resp if url.endswith('/devices') else base_resp
@@ -238,7 +247,8 @@ def test_get_user_devices_authenticated_unions_both_endpoints():
         status, devices = thief.get_user_devices_authenticated(
             "cucm.example.com", "alice", "pw", port=8443)
     assert status == "ok"
-    assert devices == ["SEP001122334455", "SEP667788990011"]
+    # base-endpoint SEP first, then /devices SEP, no duplicates
+    assert devices == ["SEP001122334455", "SEPAABBCCDDEEFF"]
     called = [c.args[0] for c in mock_get.call_args_list]
     assert "https://cucm.example.com:8443/cucm-uds/user/alice" in called
     assert "https://cucm.example.com:8443/cucm-uds/user/alice/devices" in called

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -65,6 +65,40 @@ def test_parse_uds_devices_ignores_non_sep_device_names():
 
 
 # ---------------------------------------------------------------------------
+# parse_uds_device_collection (/cucm-uds/user/{id}/devices shape)
+# ---------------------------------------------------------------------------
+
+UDS_DEVICE_COLLECTION_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<devices>
+  <device uri="https://cucm/cucm-uds/user/abc/device/1">
+    <id>1</id>
+    <name>SEP001122334455</name>
+    <model>Cisco 8845</model>
+    <description>alice desk</description>
+  </device>
+  <device uri="https://cucm/cucm-uds/user/abc/device/2">
+    <id>2</id>
+    <name>SEP667788990011</name>
+    <model>Cisco 7841</model>
+  </device>
+</devices>"""
+
+
+def test_parse_uds_device_collection_returns_sep_names():
+    assert thief.parse_uds_device_collection(UDS_DEVICE_COLLECTION_XML) == [
+        "SEP001122334455", "SEP667788990011"]
+
+
+def test_parse_uds_device_collection_empty_on_user_object_shape():
+    # The /user/{id} associatedDevices shape has no <name>SEP…</name> tags
+    assert thief.parse_uds_device_collection(UDS_USER_XML) == []
+
+
+def test_parse_uds_device_collection_empty_on_blank():
+    assert thief.parse_uds_device_collection("") == []
+
+
+# ---------------------------------------------------------------------------
 # uds_devices DB table
 # ---------------------------------------------------------------------------
 

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -160,8 +160,11 @@ def test_get_user_devices_authenticated_returns_ok_and_devices_on_200():
     assert status == "ok"
     assert devices == ["SEP001122334455", "SEP667788990011"]
     # Must send Basic auth as the end user
-    assert mock_get.call_args.kwargs.get('auth') == ("alice", "Summer2025!")
-    assert mock_get.call_args.args[0] == "https://cucm.example.com:8443/cucm-uds/user/alice"
+    for c in mock_get.call_args_list:
+        assert c.kwargs.get('auth') == ("alice", "Summer2025!")
+    called = [c.args[0] for c in mock_get.call_args_list]
+    assert "https://cucm.example.com:8443/cucm-uds/user/alice" in called
+    assert "https://cucm.example.com:8443/cucm-uds/user/alice/devices" in called
 
 
 def test_get_user_devices_authenticated_queries_target_user_with_caller_auth():
@@ -171,9 +174,11 @@ def test_get_user_devices_authenticated_queries_target_user_with_caller_auth():
             "cucm.example.com", "alice", "Summer2025!", port=8443, target_user="bob")
     assert status == "ok"
     assert devices == ["SEP001122334455", "SEP667788990011"]
-    # Path targets bob, but auth identity stays alice
-    assert mock_get.call_args.args[0] == "https://cucm.example.com:8443/cucm-uds/user/bob"
-    assert mock_get.call_args.kwargs.get('auth') == ("alice", "Summer2025!")
+    called = [c.args[0] for c in mock_get.call_args_list]
+    assert "https://cucm.example.com:8443/cucm-uds/user/bob" in called
+    assert "https://cucm.example.com:8443/cucm-uds/user/bob/devices" in called
+    for c in mock_get.call_args_list:
+        assert c.kwargs.get('auth') == ("alice", "Summer2025!")
 
 
 def test_get_user_devices_authenticated_defaults_target_to_auth_user():
@@ -181,7 +186,9 @@ def test_get_user_devices_authenticated_defaults_target_to_auth_user():
     with patch.object(thief.requests, 'get', return_value=fake_resp) as mock_get:
         thief.get_user_devices_authenticated(
             "cucm.example.com", "alice", "pw", port=8443)
-    assert mock_get.call_args.args[0] == "https://cucm.example.com:8443/cucm-uds/user/alice"
+    called = [c.args[0] for c in mock_get.call_args_list]
+    assert "https://cucm.example.com:8443/cucm-uds/user/alice" in called
+    assert "https://cucm.example.com:8443/cucm-uds/user/alice/devices" in called
 
 
 def test_get_user_devices_authenticated_returns_unauthorized_on_401():
@@ -218,6 +225,71 @@ def test_get_user_devices_authenticated_returns_error_on_unexpected_status():
             "cucm.example.com", "alice", "pw", port=8443)
     assert status == "error"
     assert devices == []
+
+
+def test_get_user_devices_authenticated_unions_both_endpoints():
+    base_resp = MagicMock(status_code=200, text=UDS_USER_XML)
+    devices_resp = MagicMock(status_code=200, text=UDS_DEVICE_COLLECTION_XML)
+
+    def side_effect(url, **kwargs):
+        return devices_resp if url.endswith('/devices') else base_resp
+
+    with patch.object(thief.requests, 'get', side_effect=side_effect) as mock_get:
+        status, devices = thief.get_user_devices_authenticated(
+            "cucm.example.com", "alice", "pw", port=8443)
+    assert status == "ok"
+    assert devices == ["SEP001122334455", "SEP667788990011"]
+    called = [c.args[0] for c in mock_get.call_args_list]
+    assert "https://cucm.example.com:8443/cucm-uds/user/alice" in called
+    assert "https://cucm.example.com:8443/cucm-uds/user/alice/devices" in called
+
+
+def test_get_user_devices_authenticated_ok_when_only_devices_endpoint_authorized():
+    base_resp = MagicMock(status_code=401, text="")
+    devices_resp = MagicMock(status_code=200, text=UDS_DEVICE_COLLECTION_XML)
+
+    def side_effect(url, **kwargs):
+        return devices_resp if url.endswith('/devices') else base_resp
+
+    with patch.object(thief.requests, 'get', side_effect=side_effect):
+        status, devices = thief.get_user_devices_authenticated(
+            "cucm.example.com", "alice", "pw", port=8443)
+    assert status == "ok"
+    assert devices == ["SEP001122334455", "SEP667788990011"]
+
+
+def test_get_user_devices_authenticated_unauthorized_only_when_neither_ok():
+    resp401 = MagicMock(status_code=401, text="")
+    with patch.object(thief.requests, 'get', return_value=resp401):
+        status, devices = thief.get_user_devices_authenticated(
+            "cucm.example.com", "alice", "pw", port=8443)
+    assert status == "unauthorized"
+    assert devices == []
+
+
+def test_get_user_devices_authenticated_error_when_both_fail():
+    with patch.object(thief.requests, 'get',
+                      side_effect=requests.exceptions.ConnectTimeout("boom")):
+        status, devices = thief.get_user_devices_authenticated(
+            "cucm.example.com", "alice", "pw", port=8443)
+    assert status == "error"
+    assert devices == []
+
+
+def test_get_user_devices_authenticated_dedups_same_sep_from_both():
+    base_resp = MagicMock(status_code=200,
+                          text="<user><associatedDevices><device>SEP001122334455</device></associatedDevices></user>")
+    devices_resp = MagicMock(status_code=200,
+                             text="<devices><device><name>SEP001122334455</name></device></devices>")
+
+    def side_effect(url, **kwargs):
+        return devices_resp if url.endswith('/devices') else base_resp
+
+    with patch.object(thief.requests, 'get', side_effect=side_effect):
+        status, devices = thief.get_user_devices_authenticated(
+            "cucm.example.com", "alice", "pw", port=8443)
+    assert status == "ok"
+    assert devices == ["SEP001122334455"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -268,6 +268,20 @@ def test_get_user_devices_authenticated_ok_when_only_devices_endpoint_authorized
     assert devices == ["SEP001122334455", "SEP667788990011"]
 
 
+def test_get_user_devices_authenticated_ok_when_only_base_endpoint_authorized():
+    base_resp = MagicMock(status_code=200, text=UDS_USER_XML)
+    devices_resp = MagicMock(status_code=401, text="")
+
+    def side_effect(url, **kwargs):
+        return devices_resp if url.endswith('/devices') else base_resp
+
+    with patch.object(thief.requests, 'get', side_effect=side_effect):
+        status, devices = thief.get_user_devices_authenticated(
+            "cucm.example.com", "alice", "pw", port=8443)
+    assert status == "ok"
+    assert devices == ["SEP001122334455", "SEP667788990011"]
+
+
 def test_get_user_devices_authenticated_unauthorized_only_when_neither_ok():
     resp401 = MagicMock(status_code=401, text="")
     with patch.object(thief.requests, 'get', return_value=resp401):


### PR DESCRIPTION
## Summary
- `--uds-devices` now queries **both** `/cucm-uds/user/{id}` and `/cucm-uds/user/{id}/devices` for each user and unions the SEP names, so a host that misconfigures authorization on one endpoint but not the other still yields devices.
- New `parse_uds_device_collection` parser handles the `/devices` collection shape (`<name>SEP…</name>`), distinct from the associatedDevices shape (`<device>SEP…</device>`).
- `get_user_devices_authenticated` keeps its `(status, devices)` contract — callers (`enumerate_devices_authenticated`, `main()`) are unchanged. Combined status: `ok` if either endpoint 200, else `unauthorized` if either 401, else `error`. Results are an order-preserving deduped union.
- Cost: ~2x requests per user; tune with `-T/--threads`.

## Test Plan
- [x] `parse_uds_device_collection` unit tests (collection shape, negative cross-shape, blank)
- [x] union of distinct SEPs across endpoints; dedup of shared SEP
- [x] misconfig cases: base-only authorized, /devices-only authorized
- [x] both 401 → unauthorized; both fail → error
- [x] both URLs hit with the same auth; target_user routing preserved
- [x] full suite green: 222 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)