### PR TITLE
chore: ignore build/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 dist/
 *.egg-info/
 src/seeyoucm_thief/_version.py
+build/


### PR DESCRIPTION
Adds `build/` to `.gitignore` — it is a local setuptools build artifact that was showing up as untracked noise in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)