### PR TITLE
fix: detect worker task_done() crash + broaden DB CUCM fallback

### DIFF
--- a/src/seeyoucm_thief/thief.py
+++ b/src/seeyoucm_thief/thief.py
@@ -3174,7 +3174,6 @@ def main():
                                 _safe_print(f'  ✗ Invalid brute_mac_len: {brute_mac_len} (must be <= 12)')
                                 with detect_lock:
                                     counts["fail"] += 1
-                                phone_queue.task_done()
                                 continue
                             partial_mac = full_mac[:prefix_len]
                             _safe_print(f'  ✓ Detected: SEP{full_mac}')
@@ -3190,13 +3189,26 @@ def main():
                                     phone_cucm = get_cucm_for_mac_from_db(full_mac, db_file)
                                     if phone_cucm:
                                         _safe_print(f'  ✓ CUCM {phone_cucm} resolved from database for SEP{full_mac}')
+                                    else:
+                                        # This exact device isn't recorded; fall
+                                        # back to a CUCM already known from an
+                                        # earlier scan of this database, but only
+                                        # when it is unambiguous.
+                                        known = set(get_known_cucm_hosts(db_file))
+                                        known |= {c for _, c in get_mac_prefixes_from_db(db_file) if c}
+                                        known = sorted(known)
+                                        if len(known) == 1:
+                                            phone_cucm = known[0]
+                                            _safe_print(f'  ✓ Using the only CUCM host known in the database: {phone_cucm}')
+                                        elif len(known) > 1:
+                                            _safe_print(f'  ✗ Multiple CUCM hosts in the database ({", ".join(known)}); cannot pick one')
+                                            _safe_print(f'  → Re-run with -H <cucm> to choose the target')
                                 if not phone_cucm:
                                     _safe_print(f'  ✗ Could not detect CUCM host from phone {phone}')
                                     _safe_print(f'  → Supply -H <cucm> (the phone was not reachable to auto-detect it)')
                                     _safe_print(f'  → Skipping this phone, continuing with others...\n')
                                     with detect_lock:
                                         counts["fail"] += 1
-                                    phone_queue.task_done()
                                     continue
 
                             _safe_print(f'  ✓ CUCM Server: {phone_cucm}')

--- a/tests/test_brute_host_prefixes.py
+++ b/tests/test_brute_host_prefixes.py
@@ -180,3 +180,44 @@ def test_brute_mac_sep_name_resolves_cucm_from_db(monkeypatch, tmp_path, capsys)
     out = capsys.readouterr().out
     assert 'resolved from database' in out
     assert 'cucm-b' in out
+
+
+def test_brute_mac_no_cucm_does_not_crash_worker(monkeypatch, tmp_path, capsys):
+    """Regression: the no-CUCM path double-called queue.task_done(), crashing
+    the detect worker with 'task_done() called too many times'."""
+    import threading
+    monkeypatch.setattr(thief, 'get_hostname_from_phone', lambda *a, **kw: None)
+    monkeypatch.setattr(thief, 'get_cucm_name_from_phone', lambda *a, **kw: None)
+    monkeypatch.setattr(thief, 'get_version', lambda *a, **kw: None)
+    db_file = str(tmp_path / 'thief.db')
+    thief.init_database(db_file)
+
+    errors = []
+    orig = threading.excepthook
+    monkeypatch.setattr(threading, 'excepthook', lambda args: errors.append(args.exc_value))
+    monkeypatch.setattr('sys.argv',
+                        ['thief', '-b', '3', '-p', 'SEPC064E4D83AAF', '--db', db_file])
+    try:
+        with pytest.raises(SystemExit):
+            thief.main()
+    finally:
+        threading.excepthook = orig
+    assert errors == [], f'worker thread raised: {errors}'
+
+
+def test_brute_mac_sep_name_uses_sole_known_cucm(monkeypatch, tmp_path, capsys):
+    """With no -H and the device not recorded, fall back to the only CUCM host
+    known in the database."""
+    monkeypatch.setattr(thief, 'get_hostname_from_phone', lambda *a, **kw: None)
+    monkeypatch.setattr(thief, 'get_cucm_name_from_phone', lambda *a, **kw: None)
+    monkeypatch.setattr(thief, 'get_version', lambda *a, **kw: None)
+    db_file = str(tmp_path / 'thief.db')
+    thief.init_database(db_file)
+    # A different device seeds a single known CUCM host.
+    thief.log_mac_prefix_to_db('cucm-only', '10.0.0.9', 'AABBCCDDEEFF', 'AABBCCDDE', db_file)
+    monkeypatch.setattr('sys.argv',
+                        ['thief', '-b', '3', '-p', 'SEPC064E4D83AAF', '--db', db_file])
+    with pytest.raises(SystemExit):
+        thief.main()
+    out = capsys.readouterr().out
+    assert 'only CUCM host known in the database: cucm-only' in out


### PR DESCRIPTION
Follow-up to the SEP-name support in v0.13.0.

## Crash fix

`--brute-mac -p SEP<MAC>` against an **unreachable** phone with **no -H** raised:

```
ValueError: task_done() called too many times
```

The detect worker's "invalid length" and "no CUCM" branches called `queue.task_done()` explicitly and then also hit `finally: task_done()` — a `continue` inside the `try` still runs the `finally`, so the item was acked twice and the worker thread died. Fixed by letting the `finally` own the single `task_done()`.

## Broaden DB CUCM fallback (requested)

When `-H` is absent and the phone is unreachable, after the exact-MAC lookup (`get_cucm_for_mac_from_db`) misses, fall back to a CUCM host already known in the database (union of `credentials`/`phone_cucm`/`cluster_servers` and `mac_prefixes`):
- exactly one known host → use it,
- more than one → list them and ask for `-H` rather than guessing.

## Testing

- Regression test capturing `threading.excepthook` proves the worker no longer raises.
- Test for the sole-known-CUCM fallback.
- Full suite: **248 passed, 2 skipped**.
- Validated live on the engagement host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)